### PR TITLE
Edit attribute only inplace XOR in widget/page properties

### DIFF
--- a/src/Components/AuthorImage.js
+++ b/src/Components/AuthorImage.js
@@ -4,7 +4,7 @@ function AuthorImage({ image }) {
   if (!image) {
     return (
       <InPlaceEditingPlaceholder center={ true }>
-        Select an image in the author page properties.
+        Click here to select an author image.
       </InPlaceEditingPlaceholder>
     );
   }

--- a/src/Components/BlogPost/BlogPostAuthor.js
+++ b/src/Components/BlogPost/BlogPostAuthor.js
@@ -9,21 +9,43 @@ function BlogPostAuthor({ author }) {
       <div className="container">
         <hr />
         <div className="row">
-          <div className="col-md-1 col-sm-4 col-xs-4">
-            <Scrivito.LinkTag to={ author }>
-              <AuthorImage image={ author.get('image') }/>
-            </Scrivito.LinkTag>
-          </div>
-          <div className="col-md-11 col-sm-8 col-xs-8">
-            <Scrivito.LinkTag to={ author }>
-              <strong className="text-greymiddle">{ author.get('title') }</strong>
-            </Scrivito.LinkTag>
-            <p>{ author.get('description') }</p>
-          </div>
+          <AuthorImageAndDescription author={ author } />
         </div>
       </div>
     </section>
   );
 }
+
+const AuthorImageAndDescription = Scrivito.connect(({ author }) => {
+  if (!author.get('image')) {
+    return (
+      <div className="col-md-12 col-sm-12 col-xs-12">
+        <AuthorDescription author={ author } />
+      </div>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      <div className="col-md-1 col-sm-4 col-xs-4">
+        <Scrivito.LinkTag to={ author }>
+          <AuthorImage image={ author.get('image') }/>
+        </Scrivito.LinkTag>
+      </div>
+      <div className="col-md-11 col-sm-8 col-xs-8">
+        <AuthorDescription author={ author } />
+      </div>
+    </React.Fragment>
+  );
+});
+
+const AuthorDescription = Scrivito.connect(({ author }) =>
+  <React.Fragment>
+    <Scrivito.LinkTag to={ author }>
+      <strong className="text-greymiddle">{ author.get('title') }</strong>
+    </Scrivito.LinkTag>
+    <p>{ author.get('description') }</p>
+  </React.Fragment>
+);
 
 export default Scrivito.connect(BlogPostAuthor);

--- a/src/Objs/Author/AuthorComponent.js
+++ b/src/Objs/Author/AuthorComponent.js
@@ -7,7 +7,9 @@ Scrivito.provideComponent('Author', ({ page }) =>
       <div className="container">
         <div className="row">
           <div className="col-md-2 col-sm-4 col-xs-4">
-            <AuthorImage image={ page.get('image') } />
+            <Scrivito.ContentTag content={ page } attribute="image">
+              <AuthorImage image={ page.get('image') } />
+            </Scrivito.ContentTag>
           </div>
           <div className="col-md-10 col-sm-8 col-xs-8">
             <Scrivito.ContentTag content={ page } attribute="title" tag="h1" className="h1" />

--- a/src/Objs/Author/AuthorEditingConfig.js
+++ b/src/Objs/Author/AuthorEditingConfig.js
@@ -11,19 +11,11 @@ Scrivito.provideEditingConfig('Author', {
   thumbnail: `/${authorObjIcon}`,
   attributes: {
     ...metaDataEditingConfigAttributes,
-    title: {
-      title: 'Name',
-    },
-    description: {
-      title: 'Description',
-    },
     image: {
       title: 'Image',
     },
   },
   properties: [
-    'title',
-    'description',
     'image',
   ],
   propertiesGroups: [socialCardsPropertiesGroup, metaDataPropertiesGroup],

--- a/src/Objs/Author/AuthorEditingConfig.js
+++ b/src/Objs/Author/AuthorEditingConfig.js
@@ -11,13 +11,7 @@ Scrivito.provideEditingConfig('Author', {
   thumbnail: `/${authorObjIcon}`,
   attributes: {
     ...metaDataEditingConfigAttributes,
-    image: {
-      title: 'Image',
-    },
   },
-  properties: [
-    'image',
-  ],
   propertiesGroups: [socialCardsPropertiesGroup, metaDataPropertiesGroup],
   initialContent: {
     ...metaDataInitialContent,

--- a/src/Objs/Event/EventEditingConfig.js
+++ b/src/Objs/Event/EventEditingConfig.js
@@ -43,17 +43,12 @@ Scrivito.provideEditingConfig('Event', {
       title: 'Country',
       description: 'E.g. USA',
     },
-    title: {
-      title: 'Title',
-      description: 'Limit to 55 characters.',
-    },
     tags: {
       title: 'Tags',
       description: 'Which tags can be associated with this event?',
     },
   },
   properties: [
-    'title',
     'date',
     'locationName',
     'locationStreetAddress',

--- a/src/Objs/Job/JobEditingConfig.js
+++ b/src/Objs/Job/JobEditingConfig.js
@@ -19,13 +19,8 @@ Scrivito.provideEditingConfig('Job', {
       title: 'Location',
       description: 'Where is this job located?',
     },
-    title: {
-      title: 'Title',
-      description: 'Limit to 55 characters.',
-    },
   },
   properties: [
-    'title',
     'location',
     'image',
   ],

--- a/src/Widgets/AddressWidget/AddressWidgetEditingConfig.js
+++ b/src/Widgets/AddressWidget/AddressWidgetEditingConfig.js
@@ -5,10 +5,6 @@ Scrivito.provideEditingConfig('AddressWidget', {
   title: 'Address',
   thumbnail: `/${addressWidgetIcon}`,
   attributes: {
-    address: {
-      title: 'Address',
-      description: 'The actual address.',
-    },
     listItems: {
       title: 'Address list items',
       description: 'E.g. phone numbers.',
@@ -32,7 +28,6 @@ Scrivito.provideEditingConfig('AddressWidget', {
   },
   properties: [
     'showLogo',
-    'address',
     'listItems',
     'showBorderBottom',
   ],

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
@@ -13,18 +13,12 @@ Scrivito.provideComponent('TestimonialSliderWidget', ({ widget }) => {
           testimonials.map(testimonial =>
             <div key={ testimonial.id() }>
               <h1 className="quote-headline text-center">&quot;</h1>
-              <Scrivito.ContentTag
-                content={ testimonial }
-                attribute="testimonial"
-                tag="p"
-                className="h4 text-center"
-              />
-              <Scrivito.ContentTag
-                content={ testimonial }
-                attribute="author"
-                tag="p"
-                className="small text-center"
-              />
+              <p className="h4 text-center">
+                { testimonial.get('testimonial') }
+              </p>
+              <p className="small text-center">
+                { testimonial.get('author') }
+              </p>
             </div>
           )
         }

--- a/src/Widgets/TextWidget/TextWidgetEditingConfig.js
+++ b/src/Widgets/TextWidget/TextWidgetEditingConfig.js
@@ -13,14 +13,9 @@ Scrivito.provideEditingConfig('TextWidget', {
         { value: 'right', title: 'Right' },
       ],
     },
-    text: {
-      title: 'Text',
-      description: 'The actual source code of this text',
-    },
   },
   properties: [
     'alignment',
-    'text',
   ],
   initialContent: {
     alignment: 'left',


### PR DESCRIPTION
Scrivito is not yet fully ready to support editing a html or string attribute "in place" and on the widget/page properties. So to avoid confusion one attribute can now only be edited "in place" XOR on the widget/page properties.