### PR TITLE
Downgraded react-images to 0.5.14.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8694,9 +8694,9 @@
       }
     },
     "react-images": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/react-images/-/react-images-0.5.15.tgz",
-      "integrity": "sha512-SSqW9HXdYLUMAz2fqRPpnztrx6IyZwyFT8kIIjWTGAtwYbBqjbexwuOqs0gFCfjbq6L85BusLsgyaMSZ6havbA==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/react-images/-/react-images-0.5.14.tgz",
+      "integrity": "sha1-AkEKP6Y6Tt394Zomu449x1jS1Eo=",
       "dev": true,
       "requires": {
         "aphrodite": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-draggable": "^3.0.5",
     "react-helmet": "^5.1.3",
     "react-highlight-words": "^0.10.0",
-    "react-images": "^0.5.15",
+    "react-images": "^0.5.14",
     "react-scroll": "^1.7.6",
     "react-slick": "^0.16.0",
     "sass-loader": "^6.0.6",


### PR DESCRIPTION
Version 0.5.15 and 0.5.16 do not work with the prerenderer of Netlify. Fixes #3.

> npm install --save-dev react-images@0.5.14

Prove: `curl -A twitterbot https://5a71b243efbe5d6f4c9722e6--scrivito-example.netlify.com/` (Preview deploy URL of netlify).

Bonus: This reduces the payload of `index.js` by ~100 kb! Next time I do npm package update I'll have a closer look on the resulting size.