### PR TITLE
ImageWidget: Added optional "link" attribute.

### DIFF
--- a/src/Widgets/ImageWidget/ImageWidgetClass.js
+++ b/src/Widgets/ImageWidget/ImageWidgetClass.js
@@ -3,6 +3,7 @@ const ImageWidget = Scrivito.provideWidgetClass('ImageWidget', {
     image: 'reference',
     alignment: ['enum', { values: ['left', 'center', 'right'] }],
     alternativeText: 'string',
+    link: 'link',
   },
 });
 

--- a/src/Widgets/ImageWidget/ImageWidgetComponent.js
+++ b/src/Widgets/ImageWidget/ImageWidgetComponent.js
@@ -1,9 +1,16 @@
 Scrivito.provideComponent('ImageWidget', ({ widget }) => {
-  const image = <Scrivito.ImageTag
+  let image = <Scrivito.ImageTag
     content={ widget }
     attribute="image"
     alt={ alternativeText(widget) }
   />;
+
+  const link = widget.get('link');
+  if (link && !Scrivito.isInPlaceEditingActive()) {
+    image = <Scrivito.LinkTag to={ link }>
+      { image }
+    </Scrivito.LinkTag>;
+  }
 
   if (['center', 'right'].includes(widget.get('alignment'))) {
     return (

--- a/src/Widgets/ImageWidget/ImageWidgetEditingConfig.js
+++ b/src/Widgets/ImageWidget/ImageWidgetEditingConfig.js
@@ -14,14 +14,19 @@ Scrivito.provideEditingConfig('ImageWidget', {
       ],
     },
     alternativeText: {
-      title: 'Alternative text',
+      title: 'Alternative text (optional)',
       description: 'Brief description of what the image is about.' +
         ' If empty, the alternative text of the image is used.',
     },
+    link: {
+      title: 'Link (optional)',
+      description: 'The link where this image should lead.',
+    }
   },
   properties: [
     'alignment',
     'alternativeText',
+    'link',
   ],
   initialContent: {
     alignment: 'left',


### PR DESCRIPTION
Adds a new *Link* option to `ImageWidget`:

<img width="945" alt="imagewidget with link" src="https://user-images.githubusercontent.com/86275/35679316-dfd12f8c-0756-11e8-97a4-148f5accb07e.png">

If set, the image will be a link to the given page/external URL. If in edit mode, clicking on the image opens the content browser regardless of a link set or not.
