### PR TITLE
TypeScript compatible React imports

### DIFF
--- a/src/Globals.js
+++ b/src/Globals.js
@@ -2,7 +2,7 @@
 // See https://reactjs.org/blog/2017/09/26/react-v16.0.html#javascript-environment-requirements
 import 'core-js/modules/es6.map';
 import 'core-js/modules/es6.set';
-import React from 'react';
+import * as React from 'react';
 import * as Scrivito from 'scrivito';
 
 window.React = React;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import 'Globals';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import 'Objs/index';
 import 'Widgets/index';
 import App from 'App';


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/5128#issuecomment-131638288 for an explanation

There are other imports that currently don't work out of the box for the same reason (e.g. all `lodash/xyz`), but changing these will make the imports look silly, so it's better to use `allowSyntheticDefaultImports` in a TS environment.