### PR TITLE
Explicitly require Scrivito and React.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import CurrentPageMetaData from 'Components/CurrentPageMetaData';
 import ErrorBoundary from 'Components/ErrorBoundary';
 import Footer from 'Components/Footer';

--- a/src/Components/AuthorImage.js
+++ b/src/Components/AuthorImage.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 
 function AuthorImage({ image }) {

--- a/src/Components/BlogPost/BlogPostAuthor.js
+++ b/src/Components/BlogPost/BlogPostAuthor.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import AuthorImage from 'Components/AuthorImage';
 
 function BlogPostAuthor({ author }) {

--- a/src/Components/BlogPost/BlogPostDate.js
+++ b/src/Components/BlogPost/BlogPostDate.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import formatDate from 'utils/formatDate';
 
 function BlogPostDate({ post }) {

--- a/src/Components/BlogPost/BlogPostMorePosts.js
+++ b/src/Components/BlogPost/BlogPostMorePosts.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import BlogPostPreviewList from 'Components/BlogPost/BlogPostPreviewList';
 
 function BlogPostMorePosts({ author }) {

--- a/src/Components/BlogPost/BlogPostNavigation.js
+++ b/src/Components/BlogPost/BlogPostNavigation.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import BlogPostDate from './BlogPostDate';
 
 const BlogPostNavigation = Scrivito.connect(({ currentPost }) => {

--- a/src/Components/BlogPost/BlogPostPreviewList.js
+++ b/src/Components/BlogPost/BlogPostPreviewList.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import formatDate from 'utils/formatDate';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 import textExtractFromObj from 'utils/textExtractFromObj';

--- a/src/Components/BlogPost/BlogPostTagList.js
+++ b/src/Components/BlogPost/BlogPostTagList.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import navigateToBlogWithTag from 'utils/navigateToBlogWithTag';
 
 function BlogPostTagList({ tags }) {

--- a/src/Components/CurrentPageMetaData.js
+++ b/src/Components/CurrentPageMetaData.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import Helmet from 'react-helmet';
 import getMetaData from 'utils/getMetaData';
 import favicon from 'assets/images/favicon.png';

--- a/src/Components/ErrorBoundary.js
+++ b/src/Components/ErrorBoundary.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);

--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 function Footer() {
   const root = Scrivito.Obj.root();
 

--- a/src/Components/Icon.js
+++ b/src/Components/Icon.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 function Icon({ icon, size, title }) {
   const actualIcon = icon || 'fa-coffee';
   return <i className= { ['fa', actualIcon, size].join(' ') } aria-hidden="true" title={ title }/>;

--- a/src/Components/InPlaceEditingPlaceholder.js
+++ b/src/Components/InPlaceEditingPlaceholder.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import placeholderCss from 'utils/placeholderCss';
 
 const InPlaceEditingPlaceholder = ({ children, center }) => {

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import { Element as ScrollElement } from 'react-scroll';
 import currentPageNavigationOptions from './Navigation/currentPageNavigationOptions';
 import FullNavigation from './Navigation/FullNavigation';

--- a/src/Components/Navigation/FullNavigation.js
+++ b/src/Components/Navigation/FullNavigation.js
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import BootstrapCollapse from 'react-bootstrap/lib/Collapse';
 import CollapseToggle from './CollapseToggle';
 import Logo from './Logo';

--- a/src/Components/Navigation/Logo.js
+++ b/src/Components/Navigation/Logo.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 function logoObj({ scrolled, navigationStyle }) {
   let logoVersion;
   if (scrolled) {

--- a/src/Components/Navigation/Nav.js
+++ b/src/Components/Navigation/Nav.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import NavChild from './NavChild';
 
 class Nav extends React.Component {

--- a/src/Components/Navigation/NavChild.js
+++ b/src/Components/Navigation/NavChild.js
@@ -1,3 +1,6 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
+
 class BaseNavChild extends React.Component {
   constructor(props) {
     super(props);

--- a/src/Components/Navigation/NavigationSection.js
+++ b/src/Components/Navigation/NavigationSection.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 function NavigationSection({ heightClassName }) {
   if (heightClassName !== 'full-height') { return null; }
 

--- a/src/Components/Navigation/Search.js
+++ b/src/Components/Navigation/Search.js
@@ -1,3 +1,6 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
+
 const SearchBox = Scrivito.connect(class extends React.Component {
   constructor(props) {
     super(props);

--- a/src/Components/Navigation/currentPageNavigationOptions.js
+++ b/src/Components/Navigation/currentPageNavigationOptions.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 function currentPageNavigationOptions() {
   if (Scrivito.currentPage()) {
     switch (Scrivito.currentPage().objClass()) {

--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 function PlainLinkToRoot() {
   return (
     <Scrivito.LinkTag to={ Scrivito.Obj.root() } className="btn btn-primary">

--- a/src/Components/SchemaDotOrg.js
+++ b/src/Components/SchemaDotOrg.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import isEmpty from 'is-empty';
 import isPlainObject from 'lodash/isPlainObject';
 import dataFromEvent from './SchemaDotOrg/dataFromEvent';

--- a/src/Components/SchemaDotOrg/dataFromEvent.js
+++ b/src/Components/SchemaDotOrg/dataFromEvent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import formatDate from 'utils/formatDate';
 import urlFromBinary from 'utils/urlFromBinary';
 

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import ColumnWidget from 'Widgets/ColumnWidget/ColumnWidgetClass';
 import Draggable from 'react-draggable';
 import flatten from 'lodash/flatten';

--- a/src/Components/ScrivitoExtensions/IconEditorTab.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import IconComponent from 'Components/Icon';
 import AllIcons from './IconEditorTab/AllIcons';
 import IconSearch from './IconEditorTab/IconSearch';

--- a/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import take from 'lodash/take';
 import fontAwesomeIcons from './fontAwesomeIcons';
 

--- a/src/Components/ScrivitoExtensions/IconEditorTab/IconSearchResults.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/IconSearchResults.js
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import Fuse from 'fuse.js';
 import fontAwesomeIcons from './fontAwesomeIcons';
 import SingleIcon from './SingleIcon';

--- a/src/Components/ScrivitoExtensions/SocialCardsTab.js
+++ b/src/Components/ScrivitoExtensions/SocialCardsTab.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import getMetaData from 'utils/getMetaData';
 
 Scrivito.registerComponent('SocialCardsTab', ({ obj }) =>

--- a/src/Objs/Author/AuthorComponent.js
+++ b/src/Objs/Author/AuthorComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import AuthorImage from 'Components/AuthorImage';
 import BlogPostMorePosts from 'Components/BlogPost/BlogPostMorePosts';
 

--- a/src/Objs/Author/AuthorEditingConfig.js
+++ b/src/Objs/Author/AuthorEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import authorObjIcon from 'assets/images/author_obj.svg';
 import {
   metaDataEditingConfigAttributes,

--- a/src/Objs/Author/AuthorObjClass.js
+++ b/src/Objs/Author/AuthorObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 

--- a/src/Objs/Blog/BlogComponent.js
+++ b/src/Objs/Blog/BlogComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import BlogPost from 'Objs/BlogPost/BlogPostObjClass';
 import navigateToBlogWithTag from 'utils/navigateToBlogWithTag';
 import TagList from 'Components/TagList';

--- a/src/Objs/Blog/BlogEditingConfig.js
+++ b/src/Objs/Blog/BlogEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import blogObjIcon from 'assets/images/blog_obj.svg';
 import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
 import {

--- a/src/Objs/Blog/BlogObjClass.js
+++ b/src/Objs/Blog/BlogObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 

--- a/src/Objs/BlogPost/BlogPostComponent.js
+++ b/src/Objs/BlogPost/BlogPostComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import BlogPostAuthor from 'Components/BlogPost/BlogPostAuthor';
 import BlogPostMorePosts from 'Components/BlogPost/BlogPostMorePosts';
 import BlogPostNavigation from 'Components/BlogPost/BlogPostNavigation';

--- a/src/Objs/BlogPost/BlogPostEditingConfig.js
+++ b/src/Objs/BlogPost/BlogPostEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import blogPostObjIcon from 'assets/images/blog_post_obj.svg';
 import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
 import {

--- a/src/Objs/BlogPost/BlogPostObjClass.js
+++ b/src/Objs/BlogPost/BlogPostObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 

--- a/src/Objs/Download/DownloadEditingConfig.js
+++ b/src/Objs/Download/DownloadEditingConfig.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideEditingConfig('Download', {
   attributes: {
     tags: {

--- a/src/Objs/Download/DownloadObjClass.js
+++ b/src/Objs/Download/DownloadObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const Download = Scrivito.provideObjClass('Download', {

--- a/src/Objs/Event/EventComponent.js
+++ b/src/Objs/Event/EventComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import formatDate from 'utils/formatDate';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 import SchemaDotOrg from 'Components/SchemaDotOrg';

--- a/src/Objs/Event/EventEditingConfig.js
+++ b/src/Objs/Event/EventEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import eventObjIcon from 'assets/images/event_obj.svg';
 import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
 import {

--- a/src/Objs/Event/EventObjClass.js
+++ b/src/Objs/Event/EventObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 

--- a/src/Objs/Homepage/HomepageComponent.js
+++ b/src/Objs/Homepage/HomepageComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('Homepage', ({ page }) =>
   <Scrivito.ContentTag tag="div" content={ page } attribute="body" />
 );

--- a/src/Objs/Homepage/HomepageEditingConfig.js
+++ b/src/Objs/Homepage/HomepageEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import homepageObjIcon from 'assets/images/homepage_obj.svg';
 import {
   defaultPageEditingConfigAttributes,

--- a/src/Objs/Homepage/HomepageObjClass.js
+++ b/src/Objs/Homepage/HomepageObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 import defaultPageAttributes from '../_defaultPageAttributes';
 import metaDataAttributes from '../_metaDataAttributes';

--- a/src/Objs/Image/ImageEditingConfig.js
+++ b/src/Objs/Image/ImageEditingConfig.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideEditingConfig('Image', {
   attributes: {
     tags: {

--- a/src/Objs/Image/ImageObjClass.js
+++ b/src/Objs/Image/ImageObjClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const Image = Scrivito.provideObjClass('Image', {
   attributes: {
     blob: 'binary',

--- a/src/Objs/Job/JobComponent.js
+++ b/src/Objs/Job/JobComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('Job', ({ page }) => {
   return (
     <div>

--- a/src/Objs/Job/JobEditingConfig.js
+++ b/src/Objs/Job/JobEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import jobObjIcon from 'assets/images/job_obj.svg';
 import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
 import {

--- a/src/Objs/Job/JobObjClass.js
+++ b/src/Objs/Job/JobObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 

--- a/src/Objs/LandingPage/LandingPageComponent.js
+++ b/src/Objs/LandingPage/LandingPageComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('LandingPage', ({ page }) =>
   <Scrivito.ContentTag tag="div" content={ page } attribute="body" />
 );

--- a/src/Objs/LandingPage/LandingPageEditingConfig.js
+++ b/src/Objs/LandingPage/LandingPageEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import landingPageObjIcon from 'assets/images/landing_page_obj.svg';
 import {
   defaultPageEditingConfigAttributes,

--- a/src/Objs/LandingPage/LandingPageObjClass.js
+++ b/src/Objs/LandingPage/LandingPageObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 import defaultPageAttributes from '../_defaultPageAttributes';

--- a/src/Objs/Page/PageComponent.js
+++ b/src/Objs/Page/PageComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('Page', ({ page }) =>
   <Scrivito.ContentTag tag="div" content={ page } attribute="body" />
 );

--- a/src/Objs/Page/PageEditingConfig.js
+++ b/src/Objs/Page/PageEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import PageObjIcon from 'assets/images/page_obj.svg';
 import {
   defaultPageEditingConfigAttributes,

--- a/src/Objs/Page/PageObjClass.js
+++ b/src/Objs/Page/PageObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 import defaultPageAttributes from '../_defaultPageAttributes';

--- a/src/Objs/SearchResults/SearchInput.js
+++ b/src/Objs/SearchResults/SearchInput.js
@@ -1,3 +1,6 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
+
 class SearchInput extends React.Component {
   constructor(props) {
     super(props);

--- a/src/Objs/SearchResults/SearchResultItem.js
+++ b/src/Objs/SearchResults/SearchResultItem.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import Highlighter from 'react-highlight-words';
 import fromNow from 'moment-from-now';
 import textExtractFromObj from 'utils/textExtractFromObj';

--- a/src/Objs/SearchResults/SearchResultsComponent.js
+++ b/src/Objs/SearchResults/SearchResultsComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import ShowMoreButton from './ShowMoreButton';
 import SearchInput from './SearchInput';
 import SearchResultItem from './SearchResultItem';

--- a/src/Objs/SearchResults/SearchResultsEditingConfig.js
+++ b/src/Objs/SearchResults/SearchResultsEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import SearchResultsObjIcon from 'assets/images/search_results_obj.svg';
 import {
   metaDataEditingConfigAttributes,

--- a/src/Objs/SearchResults/SearchResultsObjClass.js
+++ b/src/Objs/SearchResults/SearchResultsObjClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import metaDataAttributes from '../_metaDataAttributes';
 
 const SearchResults = Scrivito.provideObjClass('SearchResults', {

--- a/src/Objs/SearchResults/SearchResultsTagList.js
+++ b/src/Objs/SearchResults/SearchResultsTagList.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import TagList from 'Components/TagList';
 
 function SearchResultsTagList({ tags, params }) {

--- a/src/Objs/SearchResults/ShowMoreButton.js
+++ b/src/Objs/SearchResults/ShowMoreButton.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 function ShowMoreButton({ currentMaxItems, totalCount, onClick }) {
   if (currentMaxItems >= totalCount) { return null; }
 

--- a/src/Objs/Video/VideoEditingConfig.js
+++ b/src/Objs/Video/VideoEditingConfig.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideEditingConfig('Video', {
   attributes: {
     tags: {

--- a/src/Objs/Video/VideoObjClass.js
+++ b/src/Objs/Video/VideoObjClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const Video = Scrivito.provideObjClass('Video', {
   attributes: {
     blob: 'binary',

--- a/src/Widgets/AddressWidget/AddressWidgetClass.js
+++ b/src/Widgets/AddressWidget/AddressWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const AddressWidget = Scrivito.provideWidgetClass('AddressWidget', {

--- a/src/Widgets/AddressWidget/AddressWidgetComponent.js
+++ b/src/Widgets/AddressWidget/AddressWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 import SchemaDotOrg from 'Components/SchemaDotOrg';
 

--- a/src/Widgets/AddressWidget/AddressWidgetEditingConfig.js
+++ b/src/Widgets/AddressWidget/AddressWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import addressWidgetIcon from 'assets/images/address_widget.svg';
 
 Scrivito.provideEditingConfig('AddressWidget', {

--- a/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetClass.js
+++ b/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const BlogOverviewWidget = Scrivito.provideWidgetClass('BlogOverviewWidget', {
   attributes: {
     maxItems: 'integer',

--- a/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
+++ b/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import BlogPostPreviewList from 'Components/BlogPost/BlogPostPreviewList';
 
 Scrivito.provideComponent('BlogOverviewWidget', ({ widget }) => {

--- a/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetEditingConfig.js
+++ b/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import blogOverviewWidgetIcon from 'assets/images/blog_overview_widget.svg';
 
 Scrivito.provideEditingConfig('BlogOverviewWidget', {

--- a/src/Widgets/BoxWidget/BoxWidgetClass.js
+++ b/src/Widgets/BoxWidget/BoxWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const BoxWidget = Scrivito.provideWidgetClass('BoxWidget', {

--- a/src/Widgets/BoxWidget/BoxWidgetComponent.js
+++ b/src/Widgets/BoxWidget/BoxWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('BoxWidget', ({ widget }) => {
   const classNames = ['panel', 'panel-theme'];
   if (widget.get('useOffset') === 'yes') { classNames.push('box-offset'); }

--- a/src/Widgets/BoxWidget/BoxWidgetEditingConfig.js
+++ b/src/Widgets/BoxWidget/BoxWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import boxWidgetIcon from 'assets/images/box_widget.svg';
 
 Scrivito.provideEditingConfig('BoxWidget', {

--- a/src/Widgets/ButtonWidget/ButtonWidgetClass.js
+++ b/src/Widgets/ButtonWidget/ButtonWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const ButtonWidget = Scrivito.provideWidgetClass('ButtonWidget', {
   attributes: {
     target: 'link',

--- a/src/Widgets/ButtonWidget/ButtonWidgetComponent.js
+++ b/src/Widgets/ButtonWidget/ButtonWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 
 const ButtonWidgetComponent = Scrivito.connect(({ widget }) => {

--- a/src/Widgets/ButtonWidget/ButtonWidgetEditingConfig.js
+++ b/src/Widgets/ButtonWidget/ButtonWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import buttonWidgetIcon from 'assets/images/button_widget.svg';
 
 Scrivito.provideEditingConfig('ButtonWidget', {

--- a/src/Widgets/CarouselWidget/CarouselWidgetClass.js
+++ b/src/Widgets/CarouselWidget/CarouselWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const CarouselWidget = Scrivito.provideWidgetClass('CarouselWidget', {

--- a/src/Widgets/CarouselWidget/CarouselWidgetComponent.js
+++ b/src/Widgets/CarouselWidget/CarouselWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import Carousel from 'react-bootstrap/lib/Carousel';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 

--- a/src/Widgets/CarouselWidget/CarouselWidgetEditingConfig.js
+++ b/src/Widgets/CarouselWidget/CarouselWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import carouselWidgetIcon from 'assets/images/carousel_widget.svg';
 
 Scrivito.provideEditingConfig('CarouselWidget', {

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetClass.js
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const ColumnContainerWidget = Scrivito.provideWidgetClass('ColumnContainerWidget', {

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetComponent.js
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('ColumnContainerWidget', ({ widget }) => {

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetEditingConfig.js
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import columnContainerWidgetIcon from 'assets/images/column_container_widget.svg';
 import ColumnWidget from 'Widgets/ColumnWidget/ColumnWidgetClass';
 

--- a/src/Widgets/ColumnWidget/ColumnWidgetClass.js
+++ b/src/Widgets/ColumnWidget/ColumnWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const ColumnWidget = Scrivito.provideWidgetClass('ColumnWidget', {

--- a/src/Widgets/ColumnWidget/ColumnWidgetEditingConfig.js
+++ b/src/Widgets/ColumnWidget/ColumnWidgetEditingConfig.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideEditingConfig('ColumnWidget', {
   title: 'Column',
 });

--- a/src/Widgets/ContactFormWidget/ContactFormWidgetClass.js
+++ b/src/Widgets/ContactFormWidget/ContactFormWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const ContactFormWidget = Scrivito.provideWidgetClass('ContactFormWidget', {
   attributes: {
     agreementText: 'string',

--- a/src/Widgets/ContactFormWidget/ContactFormWidgetComponent.js
+++ b/src/Widgets/ContactFormWidget/ContactFormWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import './contactForm.html';
 /* This html file is needed for Netlify form handling. Updates to inputs in this file should also be
 added to contactForm.html as well. See the following link for details:

--- a/src/Widgets/ContactFormWidget/ContactFormWidgetEditingConfig.js
+++ b/src/Widgets/ContactFormWidget/ContactFormWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import contactFormWidgetIcon from 'assets/images/contact_form_widget.svg';
 
 Scrivito.provideEditingConfig('ContactFormWidget', {

--- a/src/Widgets/DividerWidget/DividerWidgetClass.js
+++ b/src/Widgets/DividerWidget/DividerWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const DividerWidget = Scrivito.provideWidgetClass('DividerWidget', {
   attributes: {
     showLogo: ['enum', { values: ['yes', 'no'] }],

--- a/src/Widgets/DividerWidget/DividerWidgetComponent.js
+++ b/src/Widgets/DividerWidget/DividerWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('DividerWidget', ({ widget }) => {
   const showLogo = widget.get('showLogo') !== 'no';
   const root = Scrivito.Obj.root();

--- a/src/Widgets/DividerWidget/DividerWidgetEditingConfig.js
+++ b/src/Widgets/DividerWidget/DividerWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import dividerWidgetIcon from 'assets/images/divider_widget.svg';
 
 Scrivito.provideEditingConfig('DividerWidget', {

--- a/src/Widgets/EventOverviewWidget/EventOverviewWidgetClass.js
+++ b/src/Widgets/EventOverviewWidget/EventOverviewWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const EventOverviewWidget = Scrivito.provideWidgetClass('EventOverviewWidget', {
   attributes: {
     maxItems: 'integer',

--- a/src/Widgets/EventOverviewWidget/EventOverviewWidgetComponent.js
+++ b/src/Widgets/EventOverviewWidget/EventOverviewWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import Event from 'Objs/Event/EventObjClass';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 import TagList from 'Components/TagList';

--- a/src/Widgets/EventOverviewWidget/EventOverviewWidgetEditingConfig.js
+++ b/src/Widgets/EventOverviewWidget/EventOverviewWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import eventOverviewWidgetIcon from 'assets/images/event_overview_widget.svg';
 
 Scrivito.provideEditingConfig('EventOverviewWidget', {

--- a/src/Widgets/FactWidget/FactWidgetClass.js
+++ b/src/Widgets/FactWidget/FactWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const FactWidget = Scrivito.provideWidgetClass('FactWidget', {

--- a/src/Widgets/FactWidget/FactWidgetComponent.js
+++ b/src/Widgets/FactWidget/FactWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('FactWidget', ({ widget }) =>
   <div className="fact">
     <Scrivito.ContentTag

--- a/src/Widgets/FactWidget/FactWidgetEditingConfig.js
+++ b/src/Widgets/FactWidget/FactWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import factWidgetIcon from 'assets/images/fact_widget.svg';
 
 Scrivito.provideEditingConfig('FactWidget', {

--- a/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetClass.js
+++ b/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const FeaturePanelWidget = Scrivito.provideWidgetClass('FeaturePanelWidget', {

--- a/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetComponent.js
+++ b/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('FeaturePanelWidget', ({ widget }) => {
   return (
     <div className="panel panel-theme panel-list">

--- a/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetEditingConfig.js
+++ b/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import featurePanelWidgetIcon from 'assets/images/feature_panel_widget.svg';
 
 Scrivito.provideEditingConfig('FeaturePanelWidget', {

--- a/src/Widgets/GalleryWidget/GalleryWidgetClass.js
+++ b/src/Widgets/GalleryWidget/GalleryWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const GalleryWidget = Scrivito.provideWidgetClass('GalleryWidget', {
   attributes: {
     images: 'referencelist',

--- a/src/Widgets/GalleryWidget/GalleryWidgetComponent.js
+++ b/src/Widgets/GalleryWidget/GalleryWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 import Slider from 'react-slick';
 

--- a/src/Widgets/GalleryWidget/GalleryWidgetEditingConfig.js
+++ b/src/Widgets/GalleryWidget/GalleryWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import galleryWidgetIcon from 'assets/images/gallery_widget.svg';
 
 Scrivito.provideEditingConfig('GalleryWidget', {

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetClass.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const GoogleMapsWidget = Scrivito.provideWidgetClass('GoogleMapsWidget', {

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import googleMapsApiKey from 'utils/googleMapsApiKey';
 import googleMapsImageUrl from 'utils/googleMapsImageUrl';
 

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetEditingConfig.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import googleMapsWidgetIcon from 'assets/images/google_maps_widget.svg';
 
 Scrivito.provideEditingConfig('GoogleMapsWidget', {

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetClass.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const HeadlineWidget = Scrivito.provideWidgetClass('HeadlineWidget', {

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('HeadlineWidget', ({ widget }) => {
   const style = widget.get('style') || 'h1';
   const level = widget.get('level') || style;

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetEditingConfig.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import headlineWidgetIcon from 'assets/images/headline_widget.svg';
 
 Scrivito.provideEditingConfig('HeadlineWidget', {

--- a/src/Widgets/IconContainerWidget/IconContainerWidgetClass.js
+++ b/src/Widgets/IconContainerWidget/IconContainerWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const IconContainerWidget = Scrivito.provideWidgetClass('IconContainerWidget', {
   attributes: {
     iconList: ['widgetlist', { only: 'IconWidget' }],

--- a/src/Widgets/IconContainerWidget/IconContainerWidgetComponent.js
+++ b/src/Widgets/IconContainerWidget/IconContainerWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import IconComponent from 'Components/Icon';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 

--- a/src/Widgets/IconContainerWidget/IconContainerWidgetEditingConfig.js
+++ b/src/Widgets/IconContainerWidget/IconContainerWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import iconContainerWidgetIcon from 'assets/images/icon_container_widget.svg';
 import IconWidget from 'Widgets/IconWidget/IconWidgetClass';
 

--- a/src/Widgets/IconWidget/IconWidgetClass.js
+++ b/src/Widgets/IconWidget/IconWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const IconWidget = Scrivito.provideWidgetClass('IconWidget', {
   attributes: {
     icon: 'string',

--- a/src/Widgets/IconWidget/IconWidgetComponent.js
+++ b/src/Widgets/IconWidget/IconWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import IconComponent from 'Components/Icon';
 
 function IconWidgetComponent({ widget }) {

--- a/src/Widgets/IconWidget/IconWidgetEditingConfig.js
+++ b/src/Widgets/IconWidget/IconWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import iconWidgetIcon from 'assets/images/icon_widget.svg';
 
 Scrivito.provideEditingConfig('IconWidget', {

--- a/src/Widgets/ImageWidget/ImageWidgetClass.js
+++ b/src/Widgets/ImageWidget/ImageWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const ImageWidget = Scrivito.provideWidgetClass('ImageWidget', {
   attributes: {
     image: 'reference',

--- a/src/Widgets/ImageWidget/ImageWidgetComponent.js
+++ b/src/Widgets/ImageWidget/ImageWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('ImageWidget', ({ widget }) => {
   let image = <Scrivito.ImageTag
     content={ widget }

--- a/src/Widgets/ImageWidget/ImageWidgetEditingConfig.js
+++ b/src/Widgets/ImageWidget/ImageWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import imageWidgetIcon from 'assets/images/image_widget.svg';
 
 Scrivito.provideEditingConfig('ImageWidget', {

--- a/src/Widgets/JobOverviewWidget/JobOverviewWidgetClass.js
+++ b/src/Widgets/JobOverviewWidget/JobOverviewWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const JobOverviewWidget = Scrivito.provideWidgetClass('JobOverviewWidget', {
   attributes: {
     location: 'string',

--- a/src/Widgets/JobOverviewWidget/JobOverviewWidgetComponent.js
+++ b/src/Widgets/JobOverviewWidget/JobOverviewWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('JobOverviewWidget', ({ widget }) => {

--- a/src/Widgets/JobOverviewWidget/JobOverviewWidgetEditingConfig.js
+++ b/src/Widgets/JobOverviewWidget/JobOverviewWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import jobOverviewWidgetIcon from 'assets/images/job_overview_widget.svg';
 
 Scrivito.provideEditingConfig('JobOverviewWidget', {

--- a/src/Widgets/LinkContainerWidget/LinkContainerWidgetClass.js
+++ b/src/Widgets/LinkContainerWidget/LinkContainerWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const LinkContainerWidget = Scrivito.provideWidgetClass('LinkContainerWidget', {
   attributes: {
     headline: 'string',

--- a/src/Widgets/LinkContainerWidget/LinkContainerWidgetComponent.js
+++ b/src/Widgets/LinkContainerWidget/LinkContainerWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('LinkContainerWidget', ({ widget }) =>

--- a/src/Widgets/LinkContainerWidget/LinkContainerWidgetEditingConfig.js
+++ b/src/Widgets/LinkContainerWidget/LinkContainerWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import linkListWidgetIcon from 'assets/images/link_list_widget.svg';
 import LinkWidget from 'Widgets/LinkWidget/LinkWidgetClass';
 

--- a/src/Widgets/LinkWidget/LinkWidgetClass.js
+++ b/src/Widgets/LinkWidget/LinkWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const LinkWidget = Scrivito.provideWidgetClass('LinkWidget', {
   onlyInside: 'LinkContainerWidget',
   attributes: {

--- a/src/Widgets/LinkWidget/LinkWidgetComponent.js
+++ b/src/Widgets/LinkWidget/LinkWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('LinkWidget', ({ widget }) => {

--- a/src/Widgets/LinkWidget/LinkWidgetEditingConfig.js
+++ b/src/Widgets/LinkWidget/LinkWidgetEditingConfig.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideEditingConfig('LinkWidget', {
   title: 'Link List item',
   attributes: {

--- a/src/Widgets/PriceWidget/PriceWidgetClass.js
+++ b/src/Widgets/PriceWidget/PriceWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const PriceWidget = Scrivito.provideWidgetClass('PriceWidget', {

--- a/src/Widgets/PriceWidget/PriceWidgetComponent.js
+++ b/src/Widgets/PriceWidget/PriceWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('PriceWidget', ({ widget }) =>
   <div className="quantity">
     <Scrivito.ContentTag

--- a/src/Widgets/PriceWidget/PriceWidgetEditingConfig.js
+++ b/src/Widgets/PriceWidget/PriceWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import priceWidgetIcon from 'assets/images/price_widget.svg';
 
 Scrivito.provideEditingConfig('PriceWidget', {

--- a/src/Widgets/PricingSpecWidget/PricingSpecWidgetClass.js
+++ b/src/Widgets/PricingSpecWidget/PricingSpecWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const PricingSpecWidget = Scrivito.provideWidgetClass('PricingSpecWidget', {

--- a/src/Widgets/PricingSpecWidget/PricingSpecWidgetComponent.js
+++ b/src/Widgets/PricingSpecWidget/PricingSpecWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 
 Scrivito.provideComponent('PricingSpecWidget', ({ widget }) =>
   <div className="spec">

--- a/src/Widgets/PricingSpecWidget/PricingSpecWidgetEditingConfig.js
+++ b/src/Widgets/PricingSpecWidget/PricingSpecWidgetEditingConfig.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideEditingConfig('PricingSpecWidget', {
   title: 'Pricing Spec',
 });

--- a/src/Widgets/PricingWidget/PricingWidgetClass.js
+++ b/src/Widgets/PricingWidget/PricingWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const PricingWidget = Scrivito.provideWidgetClass('PricingWidget', {

--- a/src/Widgets/PricingWidget/PricingWidgetComponent.js
+++ b/src/Widgets/PricingWidget/PricingWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 
 function PlanButton({ target, className }) {
   const text = target && target.title();

--- a/src/Widgets/PricingWidget/PricingWidgetEditingConfig.js
+++ b/src/Widgets/PricingWidget/PricingWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import pricingWidgetIcon from 'assets/images/pricing_widget.svg';
 import PricingSpecWidget from 'Widgets/PricingSpecWidget/PricingSpecWidgetClass';
 

--- a/src/Widgets/SectionWidget/SectionWidgetClass.js
+++ b/src/Widgets/SectionWidget/SectionWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const SectionWidget = Scrivito.provideWidgetClass('SectionWidget', {

--- a/src/Widgets/SectionWidget/SectionWidgetComponent.js
+++ b/src/Widgets/SectionWidget/SectionWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('SectionWidget', ({ widget }) => {
   const sectionClassNames = [];
   const sectionStyle = {};

--- a/src/Widgets/SectionWidget/SectionWidgetEditingConfig.js
+++ b/src/Widgets/SectionWidget/SectionWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import sectionWidgetIcon from 'assets/images/section_widget.svg';
 
 Scrivito.provideEditingConfig('SectionWidget', {

--- a/src/Widgets/TableRowWidget/TableRowWidgetClass.js
+++ b/src/Widgets/TableRowWidget/TableRowWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const TableRowWidget = Scrivito.provideWidgetClass('TableRowWidget', {

--- a/src/Widgets/TableRowWidget/TableRowWidgetComponent.js
+++ b/src/Widgets/TableRowWidget/TableRowWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 function PlainTableRowWidgetComponent(
   { widget, header2, header3, header4 }
 ) {

--- a/src/Widgets/TableRowWidget/TableRowWidgetEditingConfig.js
+++ b/src/Widgets/TableRowWidget/TableRowWidgetEditingConfig.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideEditingConfig('TableRowWidget', {
   title: 'Table Row',
   titleForContent: widget => widget.get('cell1'),

--- a/src/Widgets/TableWidget/TableWidgetClass.js
+++ b/src/Widgets/TableWidget/TableWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const TableWidget = Scrivito.provideWidgetClass('TableWidget', {

--- a/src/Widgets/TableWidget/TableWidgetComponent.js
+++ b/src/Widgets/TableWidget/TableWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import placeholderCss from 'utils/placeholderCss';
 import TableRowWidget from 'Widgets/TableRowWidget/TableRowWidgetClass';
 import TableRowWidgetComponent from 'Widgets/TableRowWidget/TableRowWidgetComponent';

--- a/src/Widgets/TableWidget/TableWidgetEditingConfig.js
+++ b/src/Widgets/TableWidget/TableWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import IconWidget from 'Widgets/IconWidget/IconWidgetClass';
 import PriceWidget from 'Widgets/PriceWidget/PriceWidgetClass';
 import TableRowWidget from 'Widgets/TableRowWidget/TableRowWidgetClass';

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetClass.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const TestimonialSliderWidget = Scrivito.provideWidgetClass('TestimonialSliderWidget', {

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import Slider from 'react-slick';
 import placeholderCss from 'utils/placeholderCss';
 import TestimonialWidget from 'Widgets/TestimonialWidget/TestimonialWidgetClass';

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetEditingConfig.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import testimonialSliderWidgetIcon from 'assets/images/testimonial_slider_widget.svg';
 import TestimonialWidget from 'Widgets/TestimonialWidget/TestimonialWidgetClass';
 

--- a/src/Widgets/TestimonialWidget/TestimonialWidgetClass.js
+++ b/src/Widgets/TestimonialWidget/TestimonialWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const TestimonialWidget = Scrivito.provideWidgetClass('TestimonialWidget', {

--- a/src/Widgets/TestimonialWidget/TestimonialWidgetEditingConfig.js
+++ b/src/Widgets/TestimonialWidget/TestimonialWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import truncate from 'lodash/truncate';
 
 Scrivito.provideEditingConfig('TestimonialWidget', {

--- a/src/Widgets/TextWidget/TextWidgetClass.js
+++ b/src/Widgets/TextWidget/TextWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const TextWidget = Scrivito.provideWidgetClass('TextWidget', {

--- a/src/Widgets/TextWidget/TextWidgetComponent.js
+++ b/src/Widgets/TextWidget/TextWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('TextWidget', ({ widget }) => {
   const classNames = [];
   if (widget.get('alignment')) {

--- a/src/Widgets/TextWidget/TextWidgetEditingConfig.js
+++ b/src/Widgets/TextWidget/TextWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import textWidgetIcon from 'assets/images/text_widget.svg';
 
 Scrivito.provideEditingConfig('TextWidget', {

--- a/src/Widgets/ThumbnailGalleryImageWidget/ThumbnailGalleryImageWidgetClass.js
+++ b/src/Widgets/ThumbnailGalleryImageWidget/ThumbnailGalleryImageWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const ThumbnailGalleryImageWidget = Scrivito.provideWidgetClass('ThumbnailGalleryImageWidget', {
   onlyInside: 'ThumbnailGalleryWidget',
   attributes: {

--- a/src/Widgets/ThumbnailGalleryImageWidget/ThumbnailGalleryImageWidgetEditingConfig.js
+++ b/src/Widgets/ThumbnailGalleryImageWidget/ThumbnailGalleryImageWidgetEditingConfig.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideEditingConfig('ThumbnailGalleryImageWidget', {
   title: 'Thumbnail Gallery Image',
   attributes: {

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetClass.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const ThumbnailGalleryWidget = Scrivito.provideWidgetClass('ThumbnailGalleryWidget', {
   attributes: {
     images: ['widgetlist', { only: 'ThumbnailGalleryImageWidget' }],

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import Lightbox from 'react-images';
 import fullScreenWidthPixels from 'utils/fullScreenWidthPixels';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetEditingConfig.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import thumbnailGalleryWidgetIcon from 'assets/images/thumbnail_gallery_widget.svg';
 
 Scrivito.provideEditingConfig('ThumbnailGalleryWidget', {

--- a/src/Widgets/TickListItemWidget/TickListItemWidgetClass.js
+++ b/src/Widgets/TickListItemWidget/TickListItemWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const TickListItemWidget = Scrivito.provideWidgetClass('TickListItemWidget', {

--- a/src/Widgets/TickListItemWidget/TickListItemWidgetComponent.js
+++ b/src/Widgets/TickListItemWidget/TickListItemWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('TickListItemWidget', ({ widget }) =>
   <Scrivito.WidgetTag tag="li">
     <Scrivito.ContentTag content={ widget } attribute="statement" />

--- a/src/Widgets/TickListItemWidget/TickListItemWidgetEditingConfig.js
+++ b/src/Widgets/TickListItemWidget/TickListItemWidgetEditingConfig.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideEditingConfig('TickListItemWidget', {
   title: 'Tick List Item',
   initialContent: {

--- a/src/Widgets/TickListWidget/TickListWidgetClass.js
+++ b/src/Widgets/TickListWidget/TickListWidgetClass.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import { registerTextExtract } from 'utils/textExtractRegistry';
 
 const TickListWidget = Scrivito.provideWidgetClass('TickListWidget', {

--- a/src/Widgets/TickListWidget/TickListWidgetComponent.js
+++ b/src/Widgets/TickListWidget/TickListWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.provideComponent('TickListWidget', ({ widget }) =>
   <Scrivito.ContentTag
     tag="ul"

--- a/src/Widgets/TickListWidget/TickListWidgetEditingConfig.js
+++ b/src/Widgets/TickListWidget/TickListWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import tickListWidgetIcon from 'assets/images/tick_list_widget.svg';
 import TickListItemWidget from 'Widgets/TickListItemWidget/TickListItemWidgetClass';
 

--- a/src/Widgets/VideoWidget/VideoWidgetClass.js
+++ b/src/Widgets/VideoWidget/VideoWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const VideoWidget = Scrivito.provideWidgetClass('VideoWidget', {
   attributes: {
     source: 'reference',

--- a/src/Widgets/VideoWidget/VideoWidgetComponent.js
+++ b/src/Widgets/VideoWidget/VideoWidgetComponent.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import urlFromBinary from 'utils/urlFromBinary';
 import videoPlaceholder from './videoPlaceholder';
 

--- a/src/Widgets/VideoWidget/VideoWidgetEditingConfig.js
+++ b/src/Widgets/VideoWidget/VideoWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import videoWidgetIcon from 'assets/images/video_widget.svg';
 
 Scrivito.provideEditingConfig('VideoWidget', {

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetClass.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const VimeoVideoWidget = Scrivito.provideWidgetClass('VimeoVideoWidget', {
   attributes: {
     vimeoVideoId: 'string',

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 
 class VimeoVideoWidgetComponent extends React.Component {

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetEditingConfig.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import vimeoVideoWidgetIcon from 'assets/images/vimeo_video_widget.svg';
 
 Scrivito.provideEditingConfig('VimeoVideoWidget', {

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetClass.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetClass.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 const YoutubeVideoWidget = Scrivito.provideWidgetClass('YoutubeVideoWidget', {
   attributes: {
     youtubeVideoId: 'string',

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import * as Scrivito from 'scrivito';
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 
 class YoutubeVideoWidgetComponent extends React.Component {

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetEditingConfig.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetEditingConfig.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import youtubeVideoWidgetIcon from 'assets/images/youtube_video_widget.svg';
 
 Scrivito.provideEditingConfig('YoutubeVideoWidget', {

--- a/src/config/scrivito.js
+++ b/src/config/scrivito.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.configure({
   tenant: process.env.SCRIVITO_TENANT,
 });

--- a/src/config/scrivitoContentBrowser.js
+++ b/src/config/scrivitoContentBrowser.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 Scrivito.configureContentBrowser({
   filters: {
     _objClass: {

--- a/src/utils/getMetaData.js
+++ b/src/utils/getMetaData.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import textExtractFromObj from 'utils/textExtractFromObj';
 import truncate from 'lodash/truncate';
 import urlFromBinary from 'utils/urlFromBinary';

--- a/src/utils/googleMapsApiKey.js
+++ b/src/utils/googleMapsApiKey.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 function googleMapsApiKey() {
   const root = Scrivito.Obj.root();
   if (!root) { return ''; }

--- a/src/utils/navigateToBlogWithTag.js
+++ b/src/utils/navigateToBlogWithTag.js
@@ -1,3 +1,5 @@
+import * as Scrivito from 'scrivito';
+
 function navigateToBlogWithTag(tag) {
   const params = {};
   if (tag) {

--- a/src/utils/textExtractRegistry.js
+++ b/src/utils/textExtractRegistry.js
@@ -1,3 +1,4 @@
+import * as Scrivito from 'scrivito';
 import isString from 'utils/isString';
 
 const textExtractRegistry = {};


### PR DESCRIPTION
Leaving `window.Scrivito` still there to enable easier debugging. Also `window.React` is needed, otherwise *every* jsx component would have to manually import react.


The following ruby script has been used to do the rename:

```ruby
{
  Scrivito: "import * as Scrivito from 'scrivito';",
  React: "import * as React from 'react';",
}.each do |k, v|
  %x{ag -l -Q '#{k}.' src}.split.each do |fp|
    data = File.read(fp)

    File.open fp, 'w' do |f|
      f.write "#{v}\n"
      f.write "\n" unless (data.include? "import ")
      f.write "#{data}"
    end
  end
end
```