### PR TITLE
author image component: no image selected

### DIFF
--- a/src/Components/AuthorImage.js
+++ b/src/Components/AuthorImage.js
@@ -1,7 +1,7 @@
 import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 
 function AuthorImage({ image }) {
-  if (!image) {
+  if (!image || image.objClass() !== 'Image') {
     return (
       <InPlaceEditingPlaceholder center={ true }>
         Click here to select an author image.


### PR DESCRIPTION
If the editor selects something else than an image, it currently results in an empty "space". This is replaced with a hint to the editor.