### PR TITLE
headline widget: default style and tag should be h2

### DIFF
--- a/src/Objs/_defaultPageEditingConfig.js
+++ b/src/Objs/_defaultPageEditingConfig.js
@@ -1,3 +1,4 @@
+import HeadlineWidget from 'Widgets/HeadlineWidget/HeadlineWidgetClass';
 import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
 
 const defaultPageEditingConfigAttributes = {
@@ -29,7 +30,9 @@ const defaultPageEditingConfigAttributes = {
 };
 
 const defaultPageInitialContent = {
-  body: [new SectionWidget({})],
+  body: [new SectionWidget({
+    content: [new HeadlineWidget({ style: 'h1' })],
+  })],
   navigationHeight: 'small',
   navigationBackgroundImageGradient: 'no',
 };

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
@@ -1,5 +1,5 @@
 Scrivito.provideComponent('HeadlineWidget', ({ widget }) => {
-  const style = widget.get('style') || 'h1';
+  const style = widget.get('style') || 'h2';
   const level = widget.get('level') || style;
   const classNames = [style];
   if (widget.get('alignment')) {

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetEditingConfig.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetEditingConfig.js
@@ -6,7 +6,7 @@ Scrivito.provideEditingConfig('HeadlineWidget', {
   attributes: {
     style: {
       title: 'Style',
-      description: 'Size and font of this headline. Default: Heading 1',
+      description: 'Size and font of this headline. Default: Heading 2',
       values: [
         { value: 'h1', title: 'Heading 1' },
         { value: 'h2', title: 'Heading 2' },
@@ -67,7 +67,7 @@ Scrivito.provideEditingConfig('HeadlineWidget', {
     headline: 'Lorem Ipsum',
     showDividingLine: 'no',
     showMargin: 'yes',
-    style: 'h1',
+    style: 'h2',
   },
   titleForContent: widget => widget.get('headline'),
 });


### PR DESCRIPTION
Solves: https://trello.com/c/mJeVxUWv/292-initialcontent-for-pages-do-have-a-headline-with-h1-initialcontent-of-headlines-are-h2