### PR TITLE
Relative imports

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import CurrentPageMetaData from 'Components/CurrentPageMetaData';
-import ErrorBoundary from 'Components/ErrorBoundary';
-import Footer from 'Components/Footer';
-import Navigation from 'Components/Navigation';
-import NotFoundErrorPage from 'Components/NotFoundErrorPage';
+import CurrentPageMetaData from './Components/CurrentPageMetaData';
+import ErrorBoundary from './Components/ErrorBoundary';
+import Footer from './Components/Footer';
+import Navigation from './Components/Navigation';
+import NotFoundErrorPage from './Components/NotFoundErrorPage';
 
 export default function App() {
   return (

--- a/src/Components/AuthorImage.js
+++ b/src/Components/AuthorImage.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
-import isImage from 'utils/isImage';
+import InPlaceEditingPlaceholder from './InPlaceEditingPlaceholder';
+import isImage from '../utils/isImage';
 
 function AuthorImage({ image }) {
   if (!isImage(image)) {

--- a/src/Components/BlogPost/BlogPostAuthor.js
+++ b/src/Components/BlogPost/BlogPostAuthor.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import AuthorImage from 'Components/AuthorImage';
-import isImage from 'utils/isImage';
+import AuthorImage from '../AuthorImage';
+import isImage from '../../utils/isImage';
 
 function BlogPostAuthor({ author }) {
   if (!author) { return null; }

--- a/src/Components/BlogPost/BlogPostDate.js
+++ b/src/Components/BlogPost/BlogPostDate.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import formatDate from 'utils/formatDate';
+import formatDate from '../../utils/formatDate';
 
 function BlogPostDate({ post }) {
   const date = post.get('publishedAt');

--- a/src/Components/BlogPost/BlogPostMorePosts.js
+++ b/src/Components/BlogPost/BlogPostMorePosts.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import BlogPostPreviewList from 'Components/BlogPost/BlogPostPreviewList';
+import BlogPostPreviewList from './BlogPostPreviewList';
 
 function BlogPostMorePosts({ author }) {
   if (!author) { return null; }

--- a/src/Components/BlogPost/BlogPostPreviewList.js
+++ b/src/Components/BlogPost/BlogPostPreviewList.js
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import formatDate from 'utils/formatDate';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
-import { textExtractFromObj } from 'utils/textExtract';
 import truncate from 'lodash/truncate';
-import isImage from 'utils/isImage';
 import BlogPostDate from './BlogPostDate';
+import formatDate from '../../utils/formatDate';
+import InPlaceEditingPlaceholder from '../InPlaceEditingPlaceholder';
+import isImage from '../../utils/isImage';
+import { textExtractFromObj } from '../../utils/textExtract';
 
 const BlogPostPreviewList = Scrivito.connect(({ maxItems, author, tag }) => {
   let blogPosts = Scrivito.getClass('BlogPost').all().order('publishedAt', 'desc');

--- a/src/Components/BlogPost/BlogPostTagList.js
+++ b/src/Components/BlogPost/BlogPostTagList.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import navigateToBlogWithTag from 'utils/navigateToBlogWithTag';
+import navigateToBlogWithTag from '../../utils/navigateToBlogWithTag';
 
 function BlogPostTagList({ tags }) {
   return (

--- a/src/Components/CurrentPageMetaData.js
+++ b/src/Components/CurrentPageMetaData.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
 import Helmet from 'react-helmet';
-import getMetaData from 'utils/getMetaData';
-import favicon from 'assets/images/favicon.png';
+import getMetaData from '../utils/getMetaData';
+import favicon from '../assets/images/favicon.png';
 
 const CurrentPageMetaData = Scrivito.connect(() => {
   const htmlAttributes = { lang: 'en' };

--- a/src/Components/InPlaceEditingPlaceholder.js
+++ b/src/Components/InPlaceEditingPlaceholder.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import placeholderCss from 'utils/placeholderCss';
+import placeholderCss from '../utils/placeholderCss';
 
 const InPlaceEditingPlaceholder = ({ children, center, block }) => {
   if (!Scrivito.isInPlaceEditingActive()) {

--- a/src/Components/SchemaDotOrg/dataFromEvent.js
+++ b/src/Components/SchemaDotOrg/dataFromEvent.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import formatDate from 'utils/formatDate';
-import urlFromBinary from 'utils/urlFromBinary';
+import formatDate from '../../utils/formatDate';
+import urlFromBinary from '../../utils/urlFromBinary';
 
 function dataFromEvent(event) {
   return {

--- a/src/Components/SchemaDotOrg/dataFromJob.js
+++ b/src/Components/SchemaDotOrg/dataFromJob.js
@@ -1,5 +1,5 @@
-import formatDate from 'utils/formatDate';
-import { textExtractFromWidgetlist } from 'utils/textExtract';
+import formatDate from '../../utils/formatDate';
+import { textExtractFromWidgetlist } from '../../utils/textExtract';
 
 function dataFromJob(job) {
   return {

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import ColumnWidget from 'Widgets/ColumnWidget/ColumnWidgetClass';
 import Draggable from 'react-draggable';
 import flatten from 'lodash/flatten';
 import isEqual from 'lodash/isEqual';
@@ -8,6 +7,7 @@ import last from 'lodash/last';
 import take from 'lodash/take';
 import takeRight from 'lodash/takeRight';
 import times from 'lodash/times';
+import ColumnWidget from '../../Widgets/ColumnWidget/ColumnWidgetClass';
 
 class ColumnsEditorTab extends React.Component {
   constructor(props) {

--- a/src/Components/ScrivitoExtensions/IconEditorTab.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import IconComponent from 'Components/Icon';
 import AllIcons from './IconEditorTab/AllIcons';
+import IconComponent from '../Icon';
 import IconSearch from './IconEditorTab/IconSearch';
 import IconSearchResults from './IconEditorTab/IconSearchResults';
 

--- a/src/Components/ScrivitoExtensions/IconEditorTab/SingleIcon.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/SingleIcon.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import IconComponent from 'Components/Icon';
+import IconComponent from '../../Icon';
 
 function SingleIcon({ icon, setWidgetIcon, currentIcon }) {
   const cssIcon = `fa-${icon.id}`;

--- a/src/Components/ScrivitoExtensions/SocialCardsTab.js
+++ b/src/Components/ScrivitoExtensions/SocialCardsTab.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import getMetaData from 'utils/getMetaData';
+import getMetaData from '../../utils/getMetaData';
 
 Scrivito.registerComponent('SocialCardsTab', ({ obj }) =>
   <div className=''>

--- a/src/Objs/Author/AuthorComponent.js
+++ b/src/Objs/Author/AuthorComponent.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import AuthorImage from 'Components/AuthorImage';
-import BlogPostMorePosts from 'Components/BlogPost/BlogPostMorePosts';
+import AuthorImage from '../../Components/AuthorImage';
+import BlogPostMorePosts from '../../Components/BlogPost/BlogPostMorePosts';
 
 Scrivito.provideComponent('Author', ({ page }) =>
   <React.Fragment>

--- a/src/Objs/Author/AuthorEditingConfig.js
+++ b/src/Objs/Author/AuthorEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import authorObjIcon from 'assets/images/author_obj.svg';
+import authorObjIcon from '../../assets/images/author_obj.svg';
 import {
   metaDataEditingConfigAttributes,
   metaDataInitialContent,

--- a/src/Objs/Author/AuthorObjClass.js
+++ b/src/Objs/Author/AuthorObjClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 
 const Author = Scrivito.provideObjClass('Author', {

--- a/src/Objs/Blog/BlogComponent.js
+++ b/src/Objs/Blog/BlogComponent.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import BlogPost from 'Objs/BlogPost/BlogPostObjClass';
-import navigateToBlogWithTag from 'utils/navigateToBlogWithTag';
-import TagList from 'Components/TagList';
+import BlogPost from '../BlogPost/BlogPostObjClass';
+import navigateToBlogWithTag from '../../utils/navigateToBlogWithTag';
+import TagList from '../../Components/TagList';
 
 Scrivito.provideComponent('Blog', ({ page, params }) => {
   const tags = [...BlogPost.all().facet('tags')].map(facet => facet.name());

--- a/src/Objs/Blog/BlogEditingConfig.js
+++ b/src/Objs/Blog/BlogEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import blogObjIcon from 'assets/images/blog_obj.svg';
-import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
+import blogObjIcon from '../../assets/images/blog_obj.svg';
+import SectionWidget from '../../Widgets/SectionWidget/SectionWidgetClass';
 import {
   metaDataEditingConfigAttributes,
   metaDataInitialContent,

--- a/src/Objs/Blog/BlogObjClass.js
+++ b/src/Objs/Blog/BlogObjClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 
 const Blog = Scrivito.provideObjClass('Blog', {

--- a/src/Objs/BlogPost/BlogPostComponent.js
+++ b/src/Objs/BlogPost/BlogPostComponent.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import BlogPostAuthor from 'Components/BlogPost/BlogPostAuthor';
-import BlogPostMorePosts from 'Components/BlogPost/BlogPostMorePosts';
-import BlogPostNavigation from 'Components/BlogPost/BlogPostNavigation';
-import BlogPostTagList from 'Components/BlogPost/BlogPostTagList';
+import BlogPostAuthor from '../../Components/BlogPost/BlogPostAuthor';
+import BlogPostMorePosts from '../../Components/BlogPost/BlogPostMorePosts';
+import BlogPostNavigation from '../../Components/BlogPost/BlogPostNavigation';
+import BlogPostTagList from '../../Components/BlogPost/BlogPostTagList';
 
 Scrivito.provideComponent('BlogPost', ({ page }) =>
   <div>

--- a/src/Objs/BlogPost/BlogPostEditingConfig.js
+++ b/src/Objs/BlogPost/BlogPostEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import blogPostObjIcon from 'assets/images/blog_post_obj.svg';
-import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
+import blogPostObjIcon from '../../assets/images/blog_post_obj.svg';
+import SectionWidget from '../../Widgets/SectionWidget/SectionWidgetClass';
 import {
   metaDataEditingConfigAttributes,
   metaDataInitialContent,

--- a/src/Objs/BlogPost/BlogPostObjClass.js
+++ b/src/Objs/BlogPost/BlogPostObjClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 
 const BlogPost = Scrivito.provideObjClass('BlogPost', {

--- a/src/Objs/Download/DownloadObjClass.js
+++ b/src/Objs/Download/DownloadObjClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const Download = Scrivito.provideObjClass('Download', {
   attributes: {

--- a/src/Objs/Event/EventComponent.js
+++ b/src/Objs/Event/EventComponent.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import formatDate from 'utils/formatDate';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
-import SchemaDotOrg from 'Components/SchemaDotOrg';
+import formatDate from '../../utils/formatDate';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
+import SchemaDotOrg from '../../Components/SchemaDotOrg';
 
 Scrivito.provideComponent('Event', ({ page }) =>
   <div>

--- a/src/Objs/Event/EventEditingConfig.js
+++ b/src/Objs/Event/EventEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import eventObjIcon from 'assets/images/event_obj.svg';
-import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
+import eventObjIcon from '../../assets/images/event_obj.svg';
+import SectionWidget from '../../Widgets/SectionWidget/SectionWidgetClass';
 import {
   metaDataEditingConfigAttributes,
   metaDataInitialContent,

--- a/src/Objs/Event/EventObjClass.js
+++ b/src/Objs/Event/EventObjClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 
 const Event = Scrivito.provideObjClass('Event', {

--- a/src/Objs/Homepage/HomepageEditingConfig.js
+++ b/src/Objs/Homepage/HomepageEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import homepageObjIcon from 'assets/images/homepage_obj.svg';
+import homepageObjIcon from '../../assets/images/homepage_obj.svg';
 import {
   defaultPageEditingConfigAttributes,
   defaultPageInitialContent,

--- a/src/Objs/Homepage/HomepageObjClass.js
+++ b/src/Objs/Homepage/HomepageObjClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 import defaultPageAttributes from '../_defaultPageAttributes';
 import metaDataAttributes from '../_metaDataAttributes';
 

--- a/src/Objs/Job/JobComponent.js
+++ b/src/Objs/Job/JobComponent.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import formatDate from 'utils/formatDate';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
-import SchemaDotOrg from 'Components/SchemaDotOrg';
+import formatDate from '../../utils/formatDate';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
+import SchemaDotOrg from '../../Components/SchemaDotOrg';
 
 Scrivito.provideComponent('Job', ({ page }) => {
   return (

--- a/src/Objs/Job/JobEditingConfig.js
+++ b/src/Objs/Job/JobEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import jobObjIcon from 'assets/images/job_obj.svg';
-import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
+import jobObjIcon from '../../assets/images/job_obj.svg';
+import SectionWidget from '../../Widgets/SectionWidget/SectionWidgetClass';
 import {
   metaDataEditingConfigAttributes,
   metaDataInitialContent,

--- a/src/Objs/Job/JobObjClass.js
+++ b/src/Objs/Job/JobObjClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 
 const Job = Scrivito.provideObjClass('Job', {

--- a/src/Objs/LandingPage/LandingPageEditingConfig.js
+++ b/src/Objs/LandingPage/LandingPageEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import landingPageObjIcon from 'assets/images/landing_page_obj.svg';
+import landingPageObjIcon from '../../assets/images/landing_page_obj.svg';
 import {
   defaultPageEditingConfigAttributes,
   defaultPageInitialContent,

--- a/src/Objs/LandingPage/LandingPageObjClass.js
+++ b/src/Objs/LandingPage/LandingPageObjClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 import defaultPageAttributes from '../_defaultPageAttributes';
 

--- a/src/Objs/Page/PageEditingConfig.js
+++ b/src/Objs/Page/PageEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import PageObjIcon from 'assets/images/page_obj.svg';
+import PageObjIcon from '../../assets/images/page_obj.svg';
 import {
   defaultPageEditingConfigAttributes,
   defaultPageInitialContent,

--- a/src/Objs/Page/PageObjClass.js
+++ b/src/Objs/Page/PageObjClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 import metaDataAttributes from '../_metaDataAttributes';
 import defaultPageAttributes from '../_defaultPageAttributes';
 

--- a/src/Objs/SearchResults/SearchResultItem.js
+++ b/src/Objs/SearchResults/SearchResultItem.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import Highlighter from 'react-highlight-words';
 import fromNow from 'moment-from-now';
-import { textExtractFromObj } from 'utils/textExtract';
+import Highlighter from 'react-highlight-words';
 import truncate from 'lodash/truncate';
+import { textExtractFromObj } from '../../utils/textExtract';
 
 const PreviewImage = Scrivito.connect(({ item }) => {
   const image = item.get('navigationBackgroundImage')

--- a/src/Objs/SearchResults/SearchResultsEditingConfig.js
+++ b/src/Objs/SearchResults/SearchResultsEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import SearchResultsObjIcon from 'assets/images/search_results_obj.svg';
+import SearchResultsObjIcon from '../../assets/images/search_results_obj.svg';
 import {
   metaDataEditingConfigAttributes,
   metaDataInitialContent,

--- a/src/Objs/SearchResults/SearchResultsTagList.js
+++ b/src/Objs/SearchResults/SearchResultsTagList.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import TagList from 'Components/TagList';
+import TagList from '../../Components/TagList';
 
 function SearchResultsTagList({ tags, params }) {
   return (

--- a/src/Objs/_defaultPageEditingConfig.js
+++ b/src/Objs/_defaultPageEditingConfig.js
@@ -1,5 +1,5 @@
-import HeadlineWidget from 'Widgets/HeadlineWidget/HeadlineWidgetClass';
-import SectionWidget from 'Widgets/SectionWidget/SectionWidgetClass';
+import HeadlineWidget from '../Widgets/HeadlineWidget/HeadlineWidgetClass';
+import SectionWidget from '../Widgets/SectionWidget/SectionWidgetClass';
 
 const defaultPageEditingConfigAttributes = {
   title: {

--- a/src/Widgets/AddressWidget/AddressWidgetClass.js
+++ b/src/Widgets/AddressWidget/AddressWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const AddressWidget = Scrivito.provideWidgetClass('AddressWidget', {
   attributes: {

--- a/src/Widgets/AddressWidget/AddressWidgetComponent.js
+++ b/src/Widgets/AddressWidget/AddressWidgetComponent.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
-import SchemaDotOrg from 'Components/SchemaDotOrg';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
+import SchemaDotOrg from '../../Components/SchemaDotOrg';
 
 Scrivito.provideComponent('AddressWidget', ({ widget }) => {
   return (

--- a/src/Widgets/AddressWidget/AddressWidgetEditingConfig.js
+++ b/src/Widgets/AddressWidget/AddressWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import addressWidgetIcon from 'assets/images/address_widget.svg';
+import addressWidgetIcon from '../../assets/images/address_widget.svg';
 
 Scrivito.provideEditingConfig('AddressWidget', {
   title: 'Address',

--- a/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
+++ b/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import BlogPostPreviewList from 'Components/BlogPost/BlogPostPreviewList';
+import BlogPostPreviewList from '../../Components/BlogPost/BlogPostPreviewList';
 
 Scrivito.provideComponent('BlogOverviewWidget', ({ widget }) => {
   let tag = Scrivito.currentPageParams().tag;

--- a/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetEditingConfig.js
+++ b/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import blogOverviewWidgetIcon from 'assets/images/blog_overview_widget.svg';
+import blogOverviewWidgetIcon from '../../assets/images/blog_overview_widget.svg';
 
 Scrivito.provideEditingConfig('BlogOverviewWidget', {
   title: 'Blog Overview',

--- a/src/Widgets/BoxWidget/BoxWidgetClass.js
+++ b/src/Widgets/BoxWidget/BoxWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const BoxWidget = Scrivito.provideWidgetClass('BoxWidget', {
   attributes: {

--- a/src/Widgets/BoxWidget/BoxWidgetEditingConfig.js
+++ b/src/Widgets/BoxWidget/BoxWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import boxWidgetIcon from 'assets/images/box_widget.svg';
+import boxWidgetIcon from '../../assets/images/box_widget.svg';
 
 Scrivito.provideEditingConfig('BoxWidget', {
   title: 'Box',

--- a/src/Widgets/ButtonWidget/ButtonWidgetComponent.js
+++ b/src/Widgets/ButtonWidget/ButtonWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 const ButtonWidgetComponent = Scrivito.connect(({ widget }) => {
   const target = widget.get('target');

--- a/src/Widgets/ButtonWidget/ButtonWidgetEditingConfig.js
+++ b/src/Widgets/ButtonWidget/ButtonWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import buttonWidgetIcon from 'assets/images/button_widget.svg';
+import buttonWidgetIcon from '../../assets/images/button_widget.svg';
 
 Scrivito.provideEditingConfig('ButtonWidget', {
   title: 'Button',

--- a/src/Widgets/CarouselWidget/CarouselWidgetClass.js
+++ b/src/Widgets/CarouselWidget/CarouselWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const CarouselWidget = Scrivito.provideWidgetClass('CarouselWidget', {
   attributes: {

--- a/src/Widgets/CarouselWidget/CarouselWidgetComponent.js
+++ b/src/Widgets/CarouselWidget/CarouselWidgetComponent.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
 import Carousel from 'react-bootstrap/lib/Carousel';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('CarouselWidget', ({ widget }) => {
   const images = widget.get('images');

--- a/src/Widgets/CarouselWidget/CarouselWidgetEditingConfig.js
+++ b/src/Widgets/CarouselWidget/CarouselWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import carouselWidgetIcon from 'assets/images/carousel_widget.svg';
+import carouselWidgetIcon from '../../assets/images/carousel_widget.svg';
 
 Scrivito.provideEditingConfig('CarouselWidget', {
   title: 'Carousel',

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetClass.js
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const ColumnContainerWidget = Scrivito.provideWidgetClass('ColumnContainerWidget', {
   attributes: {

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetComponent.js
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('ColumnContainerWidget', ({ widget }) => {
   const columns = widget.get('columns');

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetEditingConfig.js
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import columnContainerWidgetIcon from 'assets/images/column_container_widget.svg';
-import ColumnWidget from 'Widgets/ColumnWidget/ColumnWidgetClass';
+import columnContainerWidgetIcon from '../../assets/images/column_container_widget.svg';
+import ColumnWidget from '../ColumnWidget/ColumnWidgetClass';
 
 Scrivito.provideEditingConfig('ColumnContainerWidget', {
   title: 'Columns',

--- a/src/Widgets/ColumnWidget/ColumnWidgetClass.js
+++ b/src/Widgets/ColumnWidget/ColumnWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const ColumnWidget = Scrivito.provideWidgetClass('ColumnWidget', {
   onlyInside: 'ColumnContainerWidget',

--- a/src/Widgets/ContactFormWidget/ContactFormWidgetEditingConfig.js
+++ b/src/Widgets/ContactFormWidget/ContactFormWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import contactFormWidgetIcon from 'assets/images/contact_form_widget.svg';
+import contactFormWidgetIcon from '../../assets/images/contact_form_widget.svg';
 
 Scrivito.provideEditingConfig('ContactFormWidget', {
   title: 'Contact Form',

--- a/src/Widgets/DividerWidget/DividerWidgetEditingConfig.js
+++ b/src/Widgets/DividerWidget/DividerWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import dividerWidgetIcon from 'assets/images/divider_widget.svg';
+import dividerWidgetIcon from '../../assets/images/divider_widget.svg';
 
 Scrivito.provideEditingConfig('DividerWidget', {
   title: 'Divider',

--- a/src/Widgets/EventOverviewWidget/EventOverviewWidgetComponent.js
+++ b/src/Widgets/EventOverviewWidget/EventOverviewWidgetComponent.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import Event from 'Objs/Event/EventObjClass';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
-import TagList from 'Components/TagList';
-import formatDate from 'utils/formatDate';
+import Event from '../../Objs/Event/EventObjClass';
+import formatDate from '../../utils/formatDate';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
+import TagList from '../../Components/TagList';
 
 class EventOverviewWidgetComponent extends React.Component {
   constructor(props) {

--- a/src/Widgets/EventOverviewWidget/EventOverviewWidgetEditingConfig.js
+++ b/src/Widgets/EventOverviewWidget/EventOverviewWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import eventOverviewWidgetIcon from 'assets/images/event_overview_widget.svg';
+import eventOverviewWidgetIcon from '../../assets/images/event_overview_widget.svg';
 
 Scrivito.provideEditingConfig('EventOverviewWidget', {
   title: 'Event Overview',

--- a/src/Widgets/FactWidget/FactWidgetClass.js
+++ b/src/Widgets/FactWidget/FactWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const FactWidget = Scrivito.provideWidgetClass('FactWidget', {
   attributes: {

--- a/src/Widgets/FactWidget/FactWidgetEditingConfig.js
+++ b/src/Widgets/FactWidget/FactWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import factWidgetIcon from 'assets/images/fact_widget.svg';
+import factWidgetIcon from '../../assets/images/fact_widget.svg';
 
 Scrivito.provideEditingConfig('FactWidget', {
   title: 'Fact',

--- a/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetClass.js
+++ b/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const FeaturePanelWidget = Scrivito.provideWidgetClass('FeaturePanelWidget', {
   attributes: {

--- a/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetEditingConfig.js
+++ b/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import featurePanelWidgetIcon from 'assets/images/feature_panel_widget.svg';
+import featurePanelWidgetIcon from '../../assets/images/feature_panel_widget.svg';
 
 Scrivito.provideEditingConfig('FeaturePanelWidget', {
   title: 'Feature Panel',

--- a/src/Widgets/GalleryWidget/GalleryWidgetComponent.js
+++ b/src/Widgets/GalleryWidget/GalleryWidgetComponent.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
 import Slider from 'react-slick';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 function GalleryWidgetComponent({ widget }) {
   const images = widget.get('images');

--- a/src/Widgets/GalleryWidget/GalleryWidgetEditingConfig.js
+++ b/src/Widgets/GalleryWidget/GalleryWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import galleryWidgetIcon from 'assets/images/gallery_widget.svg';
+import galleryWidgetIcon from '../../assets/images/gallery_widget.svg';
 
 Scrivito.provideEditingConfig('GalleryWidget', {
   title: 'Gallery',

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetClass.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const GoogleMapsWidget = Scrivito.provideWidgetClass('GoogleMapsWidget', {
   attributes: {

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import googleMapsApiKey from 'utils/googleMapsApiKey';
-import googleMapsImageUrl from 'utils/googleMapsImageUrl';
+import googleMapsApiKey from '../../utils/googleMapsApiKey';
+import googleMapsImageUrl from '../../utils/googleMapsImageUrl';
 
 const maxWidth = 640;
 

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetEditingConfig.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import googleMapsWidgetIcon from 'assets/images/google_maps_widget.svg';
+import googleMapsWidgetIcon from '../../assets/images/google_maps_widget.svg';
 
 Scrivito.provideEditingConfig('GoogleMapsWidget', {
   title: 'Google Maps',

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetClass.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const HeadlineWidget = Scrivito.provideWidgetClass('HeadlineWidget', {
   attributes: {

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetEditingConfig.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import headlineWidgetIcon from 'assets/images/headline_widget.svg';
+import headlineWidgetIcon from '../../assets/images/headline_widget.svg';
 
 Scrivito.provideEditingConfig('HeadlineWidget', {
   title: 'Headline',

--- a/src/Widgets/IconContainerWidget/IconContainerWidgetComponent.js
+++ b/src/Widgets/IconContainerWidget/IconContainerWidgetComponent.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import IconComponent from 'Components/Icon';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
+import IconComponent from '../../Components/Icon';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('IconContainerWidget', ({ widget }) => {
   const icons = widget.get('iconList');

--- a/src/Widgets/IconContainerWidget/IconContainerWidgetEditingConfig.js
+++ b/src/Widgets/IconContainerWidget/IconContainerWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import iconContainerWidgetIcon from 'assets/images/icon_container_widget.svg';
-import IconWidget from 'Widgets/IconWidget/IconWidgetClass';
+import iconContainerWidgetIcon from '../../assets/images/icon_container_widget.svg';
+import IconWidget from '../IconWidget/IconWidgetClass';
 
 Scrivito.provideEditingConfig('IconContainerWidget', {
   title: 'Icon List',

--- a/src/Widgets/IconWidget/IconWidgetComponent.js
+++ b/src/Widgets/IconWidget/IconWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import IconComponent from 'Components/Icon';
+import IconComponent from '../../Components/Icon';
 
 function IconWidgetComponent({ widget }) {
   const icon = widget.get('icon');

--- a/src/Widgets/IconWidget/IconWidgetEditingConfig.js
+++ b/src/Widgets/IconWidget/IconWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import iconWidgetIcon from 'assets/images/icon_widget.svg';
+import iconWidgetIcon from '../../assets/images/icon_widget.svg';
 
 Scrivito.provideEditingConfig('IconWidget', {
   title: 'Icon',

--- a/src/Widgets/ImageWidget/ImageWidgetEditingConfig.js
+++ b/src/Widgets/ImageWidget/ImageWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import imageWidgetIcon from 'assets/images/image_widget.svg';
+import imageWidgetIcon from '../../assets/images/image_widget.svg';
 
 Scrivito.provideEditingConfig('ImageWidget', {
   title: 'Image',

--- a/src/Widgets/JobOverviewWidget/JobOverviewWidgetComponent.js
+++ b/src/Widgets/JobOverviewWidget/JobOverviewWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('JobOverviewWidget', ({ widget }) => {
   let jobsSearch = Scrivito.getClass('Job').all();

--- a/src/Widgets/JobOverviewWidget/JobOverviewWidgetEditingConfig.js
+++ b/src/Widgets/JobOverviewWidget/JobOverviewWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import jobOverviewWidgetIcon from 'assets/images/job_overview_widget.svg';
+import jobOverviewWidgetIcon from '../../assets/images/job_overview_widget.svg';
 
 Scrivito.provideEditingConfig('JobOverviewWidget', {
   title: 'Job Overview',

--- a/src/Widgets/LinkContainerWidget/LinkContainerWidgetComponent.js
+++ b/src/Widgets/LinkContainerWidget/LinkContainerWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('LinkContainerWidget', ({ widget }) =>
   <React.Fragment>

--- a/src/Widgets/LinkContainerWidget/LinkContainerWidgetEditingConfig.js
+++ b/src/Widgets/LinkContainerWidget/LinkContainerWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import linkListWidgetIcon from 'assets/images/link_list_widget.svg';
-import LinkWidget from 'Widgets/LinkWidget/LinkWidgetClass';
+import linkListWidgetIcon from '../../assets/images/link_list_widget.svg';
+import LinkWidget from '../LinkWidget/LinkWidgetClass';
 
 Scrivito.provideEditingConfig('LinkContainerWidget', {
   title: 'Link List',

--- a/src/Widgets/LinkWidget/LinkWidgetComponent.js
+++ b/src/Widgets/LinkWidget/LinkWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 Scrivito.provideComponent('LinkWidget', ({ widget }) => {
   const link = widget.get('link');

--- a/src/Widgets/PriceWidget/PriceWidgetClass.js
+++ b/src/Widgets/PriceWidget/PriceWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const PriceWidget = Scrivito.provideWidgetClass('PriceWidget', {
   onlyInside: 'TableRowWidget',

--- a/src/Widgets/PriceWidget/PriceWidgetEditingConfig.js
+++ b/src/Widgets/PriceWidget/PriceWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import priceWidgetIcon from 'assets/images/price_widget.svg';
+import priceWidgetIcon from '../../assets/images/price_widget.svg';
 
 Scrivito.provideEditingConfig('PriceWidget', {
   title: 'Price',

--- a/src/Widgets/PricingSpecWidget/PricingSpecWidgetClass.js
+++ b/src/Widgets/PricingSpecWidget/PricingSpecWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const PricingSpecWidget = Scrivito.provideWidgetClass('PricingSpecWidget', {
   onlyInside: 'PricingWidget',

--- a/src/Widgets/PricingWidget/PricingWidgetClass.js
+++ b/src/Widgets/PricingWidget/PricingWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const PricingWidget = Scrivito.provideWidgetClass('PricingWidget', {
   attributes: {

--- a/src/Widgets/PricingWidget/PricingWidgetEditingConfig.js
+++ b/src/Widgets/PricingWidget/PricingWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import pricingWidgetIcon from 'assets/images/pricing_widget.svg';
-import PricingSpecWidget from 'Widgets/PricingSpecWidget/PricingSpecWidgetClass';
+import pricingWidgetIcon from '../../assets/images/pricing_widget.svg';
+import PricingSpecWidget from '../PricingSpecWidget/PricingSpecWidgetClass';
 
 Scrivito.provideEditingConfig('PricingWidget', {
   title: 'Pricing',

--- a/src/Widgets/SectionWidget/SectionWidgetClass.js
+++ b/src/Widgets/SectionWidget/SectionWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const SectionWidget = Scrivito.provideWidgetClass('SectionWidget', {
   attributes: {

--- a/src/Widgets/SectionWidget/SectionWidgetEditingConfig.js
+++ b/src/Widgets/SectionWidget/SectionWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import sectionWidgetIcon from 'assets/images/section_widget.svg';
+import sectionWidgetIcon from '../../assets/images/section_widget.svg';
 
 Scrivito.provideEditingConfig('SectionWidget', {
   title: 'Section',

--- a/src/Widgets/TableRowWidget/TableRowWidgetClass.js
+++ b/src/Widgets/TableRowWidget/TableRowWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const TableRowWidget = Scrivito.provideWidgetClass('TableRowWidget', {
   attributes: {

--- a/src/Widgets/TableWidget/TableWidgetClass.js
+++ b/src/Widgets/TableWidget/TableWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const TableWidget = Scrivito.provideWidgetClass('TableWidget', {
   attributes: {

--- a/src/Widgets/TableWidget/TableWidgetComponent.js
+++ b/src/Widgets/TableWidget/TableWidgetComponent.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import placeholderCss from 'utils/placeholderCss';
-import TableRowWidget from 'Widgets/TableRowWidget/TableRowWidgetClass';
-import TableRowWidgetComponent from 'Widgets/TableRowWidget/TableRowWidgetComponent';
+import placeholderCss from '../../utils/placeholderCss';
+import TableRowWidget from '../TableRowWidget/TableRowWidgetClass';
+import TableRowWidgetComponent from '../TableRowWidget/TableRowWidgetComponent';
 
 Scrivito.provideComponent('TableWidget', ({ widget }) =>
   <table className="table-features">

--- a/src/Widgets/TableWidget/TableWidgetEditingConfig.js
+++ b/src/Widgets/TableWidget/TableWidgetEditingConfig.js
@@ -1,9 +1,9 @@
 import * as Scrivito from 'scrivito';
-import IconWidget from 'Widgets/IconWidget/IconWidgetClass';
-import PriceWidget from 'Widgets/PriceWidget/PriceWidgetClass';
-import TableRowWidget from 'Widgets/TableRowWidget/TableRowWidgetClass';
-import tableWidgetIcon from 'assets/images/table_widget.svg';
-import TextWidget from 'Widgets/TextWidget/TextWidgetClass';
+import IconWidget from '../IconWidget/IconWidgetClass';
+import PriceWidget from '../PriceWidget/PriceWidgetClass';
+import TableRowWidget from '../TableRowWidget/TableRowWidgetClass';
+import tableWidgetIcon from '../../assets/images/table_widget.svg';
+import TextWidget from '../TextWidget/TextWidgetClass';
 
 Scrivito.provideEditingConfig('TableWidget', {
   title: 'Table',

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetClass.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const TestimonialSliderWidget = Scrivito.provideWidgetClass('TestimonialSliderWidget', {
   attributes: {

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
 import Slider from 'react-slick';
-import placeholderCss from 'utils/placeholderCss';
-import TestimonialWidget from 'Widgets/TestimonialWidget/TestimonialWidgetClass';
-import isImage from 'utils/isImage';
+import placeholderCss from '../../utils/placeholderCss';
+import TestimonialWidget from '../TestimonialWidget/TestimonialWidgetClass';
+import isImage from '../../utils/isImage';
 
 Scrivito.provideComponent('TestimonialSliderWidget', ({ widget }) => {
   const testimonials = widget.get('testimonials');

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetEditingConfig.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import testimonialSliderWidgetIcon from 'assets/images/testimonial_slider_widget.svg';
-import TestimonialWidget from 'Widgets/TestimonialWidget/TestimonialWidgetClass';
+import testimonialSliderWidgetIcon from '../../assets/images/testimonial_slider_widget.svg';
+import TestimonialWidget from '../TestimonialWidget/TestimonialWidgetClass';
 
 Scrivito.provideEditingConfig('TestimonialSliderWidget', {
   title: 'Testimonial Slider',

--- a/src/Widgets/TestimonialWidget/TestimonialWidgetClass.js
+++ b/src/Widgets/TestimonialWidget/TestimonialWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const TestimonialWidget = Scrivito.provideWidgetClass('TestimonialWidget', {
   onlyInside: 'TestimonialSliderWidget',

--- a/src/Widgets/TextWidget/TextWidgetClass.js
+++ b/src/Widgets/TextWidget/TextWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const TextWidget = Scrivito.provideWidgetClass('TextWidget', {
   attributes: {

--- a/src/Widgets/TextWidget/TextWidgetEditingConfig.js
+++ b/src/Widgets/TextWidget/TextWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import textWidgetIcon from 'assets/images/text_widget.svg';
+import textWidgetIcon from '../../assets/images/text_widget.svg';
 
 Scrivito.provideEditingConfig('TextWidget', {
   title: 'Text',

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
 import Lightbox from 'react-images';
-import fullScreenWidthPixels from 'utils/fullScreenWidthPixels';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
-import TagList from 'Components/TagList';
-import isImage from 'utils/isImage';
+import fullScreenWidthPixels from '../../utils/fullScreenWidthPixels';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
+import TagList from '../../Components/TagList';
+import isImage from '../../utils/isImage';
 
 class ThumbnailGalleryComponent extends React.Component {
   constructor(props) {

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetEditingConfig.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import thumbnailGalleryWidgetIcon from 'assets/images/thumbnail_gallery_widget.svg';
+import thumbnailGalleryWidgetIcon from '../../assets/images/thumbnail_gallery_widget.svg';
 
 Scrivito.provideEditingConfig('ThumbnailGalleryWidget', {
   title: 'Thumbnail Gallery',

--- a/src/Widgets/TickListItemWidget/TickListItemWidgetClass.js
+++ b/src/Widgets/TickListItemWidget/TickListItemWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const TickListItemWidget = Scrivito.provideWidgetClass('TickListItemWidget', {
   attributes: {

--- a/src/Widgets/TickListWidget/TickListWidgetClass.js
+++ b/src/Widgets/TickListWidget/TickListWidgetClass.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import { registerTextExtract } from 'utils/textExtractRegistry';
+import { registerTextExtract } from '../../utils/textExtractRegistry';
 
 const TickListWidget = Scrivito.provideWidgetClass('TickListWidget', {
   attributes: {

--- a/src/Widgets/TickListWidget/TickListWidgetEditingConfig.js
+++ b/src/Widgets/TickListWidget/TickListWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from 'scrivito';
-import tickListWidgetIcon from 'assets/images/tick_list_widget.svg';
-import TickListItemWidget from 'Widgets/TickListItemWidget/TickListItemWidgetClass';
+import tickListWidgetIcon from '../../assets/images/tick_list_widget.svg';
+import TickListItemWidget from '../TickListItemWidget/TickListItemWidgetClass';
 
 Scrivito.provideEditingConfig('TickListWidget', {
   title: 'Tick List',

--- a/src/Widgets/VideoWidget/VideoWidgetComponent.js
+++ b/src/Widgets/VideoWidget/VideoWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import urlFromBinary from 'utils/urlFromBinary';
+import urlFromBinary from '../../utils/urlFromBinary';
 import videoPlaceholder from './videoPlaceholder';
 
 Scrivito.provideComponent('VideoWidget', ({ widget }) => {

--- a/src/Widgets/VideoWidget/VideoWidgetEditingConfig.js
+++ b/src/Widgets/VideoWidget/VideoWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import videoWidgetIcon from 'assets/images/video_widget.svg';
+import videoWidgetIcon from '../../assets/images/video_widget.svg';
 
 Scrivito.provideEditingConfig('VideoWidget', {
   title: 'Video',

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 class VimeoVideoWidgetComponent extends React.Component {
   constructor(props) {

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetEditingConfig.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import vimeoVideoWidgetIcon from 'assets/images/vimeo_video_widget.svg';
+import vimeoVideoWidgetIcon from '../../assets/images/vimeo_video_widget.svg';
 
 Scrivito.provideEditingConfig('VimeoVideoWidget', {
   title: 'Vimeo Video',

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import InPlaceEditingPlaceholder from 'Components/InPlaceEditingPlaceholder';
+import InPlaceEditingPlaceholder from '../../Components/InPlaceEditingPlaceholder';
 
 class YoutubeVideoWidgetComponent extends React.Component {
   constructor(props) {

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetEditingConfig.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import youtubeVideoWidgetIcon from 'assets/images/youtube_video_widget.svg';
+import youtubeVideoWidgetIcon from '../../assets/images/youtube_video_widget.svg';
 
 Scrivito.provideEditingConfig('YoutubeVideoWidget', {
   title: 'YouTube Video',

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
-import './reactPolyfills';
+// Needed polyfills for React 16 for older browsers
+// See https://reactjs.org/blog/2017/09/26/react-v16.0.html#javascript-environment-requirements
+import 'core-js/modules/es6.map';
+import 'core-js/modules/es6.set';
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import './Objs';

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import 'reactPolyfills';
+import './reactPolyfills';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import 'Objs';
-import 'Widgets';
-import App from 'App';
-import 'config';
+import './Objs';
+import './Widgets';
+import App from './App';
+import './config';
 
 ReactDOM.render(<App />, document.getElementById('application'));

--- a/src/reactPolyfills.js
+++ b/src/reactPolyfills.js
@@ -1,4 +1,0 @@
-// Needed polyfills for React 16 for older browsers
-// See https://reactjs.org/blog/2017/09/26/react-v16.0.html#javascript-environment-requirements
-import 'core-js/modules/es6.map';
-import 'core-js/modules/es6.set';

--- a/src/scrivito_extensions.js
+++ b/src/scrivito_extensions.js
@@ -1,9 +1,8 @@
+import * as React from 'react';
 import './Objs';
 import './Widgets';
 import './config';
 import './Components/ScrivitoExtensions';
 
 // TODO: Remove once https://github.com/infopark/rails_connector/issues/3829 is resolved.
-import * as React from 'react';
-
 window.React = React;

--- a/src/scrivito_extensions.js
+++ b/src/scrivito_extensions.js
@@ -1,7 +1,7 @@
-import 'Objs';
-import 'Widgets';
-import 'config';
-import 'Components/ScrivitoExtensions';
+import './Objs';
+import './Widgets';
+import './config';
+import './Components/ScrivitoExtensions';
 
 // TODO: Remove once https://github.com/infopark/rails_connector/issues/3829 is resolved.
 import * as React from 'react';

--- a/src/utils/fullScreenWidthPixels.js
+++ b/src/utils/fullScreenWidthPixels.js
@@ -1,4 +1,4 @@
-import devicePixelRatio from 'utils/devicePixelRatio';
+import devicePixelRatio from './devicePixelRatio';
 
 function fullScreenWidthPixels() {
   const screenWidth = window.screen.width;

--- a/src/utils/getMetaData.js
+++ b/src/utils/getMetaData.js
@@ -1,7 +1,7 @@
 import * as Scrivito from 'scrivito';
-import { textExtractFromObj } from 'utils/textExtract';
 import truncate from 'lodash/truncate';
-import urlFromBinary from 'utils/urlFromBinary';
+import { textExtractFromObj } from './textExtract';
+import urlFromBinary from './urlFromBinary';
 
 function getMetaData(page) {
   const meta = [

--- a/src/utils/textExtract.js
+++ b/src/utils/textExtract.js
@@ -1,6 +1,6 @@
-import isString from 'utils/isString';
-import textExtractFromHtml from 'utils/textExtractFromHtml';
-import { lookupTextExtract } from 'utils/textExtractRegistry';
+import isString from './isString';
+import { lookupTextExtract } from './textExtractRegistry';
+import textExtractFromHtml from './textExtractFromHtml';
 
 function textExtractFromObj(obj) {
   return textExtractFromItem(obj);

--- a/src/utils/textExtractRegistry.js
+++ b/src/utils/textExtractRegistry.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import isString from 'utils/isString';
+import isString from './isString';
 
 const textExtractRegistry = {};
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -133,7 +133,7 @@ module.exports = (env = {}) => {
     plugins: plugins,
     resolve: {
       extensions: ['.js'],
-      modules: ['src', 'node_modules'],
+      modules: ['node_modules'],
     },
     devServer: {
       port: 8080,


### PR DESCRIPTION
This PR changes webpack, to no longer look in `src/` for absolut imports. Instead all imports of `src/` are done relative.

### Motivation

This is more standards conform and may allow to later replace `webpack` with another js compiler.