### PR TITLE
Prerender.io - correct status codes

### DIFF
--- a/src/Components/ErrorBoundary.js
+++ b/src/Components/ErrorBoundary.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Helmet from 'react-helmet';
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -17,26 +18,29 @@ class ErrorBoundary extends React.Component {
     }
 
     return (
-      <section
-        className="bg-dark-image full-height"
-        style={ { background: 'no-repeat center / cover', backgroundImage } }
-      >
-        <div className="container">
-          <div className="text-center"><h1 className="hero-bold">Sorry</h1></div>
-          <div className="text-center">
-            <h2 className="hero-small">Something went wrong.</h2>
+      <React.Fragment>
+        <section
+          className="bg-dark-image full-height"
+          style={ { background: 'no-repeat center / cover', backgroundImage } }
+        >
+          <div className="container">
+            <div className="text-center"><h1 className="hero-bold">Sorry</h1></div>
+            <div className="text-center">
+              <h2 className="hero-small">Something went wrong.</h2>
+            </div>
+            <div className="text-center">
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={ () => window.location.reload(true) }
+              >
+                Please try again<i className="fa fa-angle-right fa-4" aria-hidden="true" />
+              </button>
+            </div>
           </div>
-          <div className="text-center">
-            <button
-              type="button"
-              className="btn btn-primary"
-              onClick={ () => window.location.reload(true) }
-            >
-              Please try again<i className="fa fa-angle-right fa-4" aria-hidden="true" />
-            </button>
-          </div>
-        </div>
-      </section>
+        </section>
+        <Helmet meta={ [{ name: 'prerender-status-code', content: '500' }] } />
+      </React.Fragment>
     );
   }
 }

--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -1,16 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
 
-function PlainLinkToRoot() {
-  return (
-    <Scrivito.LinkTag to={ Scrivito.Obj.root() } className="btn btn-primary">
-      Go to mainpage<i className="fa fa-angle-right fa-4" aria-hidden="true" />
-    </Scrivito.LinkTag>
-  );
-}
-
-const LinkToRoot = Scrivito.connect(PlainLinkToRoot);
-
 function NotFoundErrorPage() {
   const backgroundImage = [
     'linear-gradient(rgba(46, 53, 60, 0.7), rgba(46, 53, 60, 0.7))',
@@ -34,5 +24,15 @@ function NotFoundErrorPage() {
     </section>
   </Scrivito.NotFoundErrorPage>;
 }
+
+function PlainLinkToRoot() {
+  return (
+    <Scrivito.LinkTag to={ Scrivito.Obj.root() } className="btn btn-primary">
+      Go to mainpage<i className="fa fa-angle-right fa-4" aria-hidden="true" />
+    </Scrivito.LinkTag>
+  );
+}
+
+const LinkToRoot = Scrivito.connect(PlainLinkToRoot);
 
 export default Scrivito.connect(NotFoundErrorPage);

--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
+import Helmet from 'react-helmet';
 
 function NotFoundErrorPage() {
   const backgroundImage = [
@@ -22,6 +23,7 @@ function NotFoundErrorPage() {
         </div>
       </div>
     </section>
+    <Helmet meta={ [{ name: 'prerender-status-code', content: '404' }] } />
   </Scrivito.NotFoundErrorPage>;
 }
 

--- a/src/utils/getMetaData.js
+++ b/src/utils/getMetaData.js
@@ -6,6 +6,7 @@ import urlFromBinary from './urlFromBinary';
 function getMetaData(page) {
   const meta = [
     { name: 'twitter:card', content: 'summary_large_image' },
+    { name: 'prerender-status-code', content: '200' },
     { property: 'og:type', content: 'article' },
     { property: 'og:url', content: Scrivito.urlFor(page) },
   ];


### PR DESCRIPTION
https://prerender.io/documentation/best-practices recommends, that a `prerender-status-code` `meta` tag will be rendered with the resulting status code.

* For regular pages status code `200` is reported.
* For not found pages status code `404` is reported.
* For the error boundary (aka internal error page)  status code `500` is reported.

### Proof

`
curl -v -A twitterbot https://deploy-preview-29--scrivito-example.netlify.com` reports `HTTP/2 200`.

`curl -v -A twitterbot https://deploy-preview-29--scrivito-example.netlify.com/doesnotexit` reports `HTTP/2 404`.

Previously not found error pages reported `HTTP/2 200`. Try it out with `curl -v -A twitterbot https://scrivito-example.netlify.com/doesnotexit`.