### PR TITLE
Add the canonical url of the current page to the HTML head section

### DIFF
--- a/src/Components/CurrentPageMetaData.js
+++ b/src/Components/CurrentPageMetaData.js
@@ -8,15 +8,6 @@ const CurrentPageMetaData = Scrivito.connect(() => {
   const htmlAttributes = { lang: 'en' };
   let title = '';
   let meta = [];
-  let canonical;
-
-  const page = Scrivito.currentPage();
-  if (page) {
-    title = page.get('title') || '';
-    meta = getMetaData(page);
-    canonical = <link rel='canonical' href={ Scrivito.urlFor(page) } />;
-  }
-
   const links = [
     {
       rel: 'shortcut icon',
@@ -25,14 +16,19 @@ const CurrentPageMetaData = Scrivito.connect(() => {
     },
   ];
 
+  const page = Scrivito.currentPage();
+  if (page) {
+    title = page.get('title') || '';
+    meta = getMetaData(page);
+    links.push({ rel: 'canonical', href: Scrivito.urlFor(page) });
+  }
+
   return <Helmet
     meta={ meta }
     htmlAttributes={ htmlAttributes }
     title={ title }
     link={ links }
-  >
-    { canonical }
-  </Helmet>;
+  />;
 });
 
 export default CurrentPageMetaData;

--- a/src/Components/CurrentPageMetaData.js
+++ b/src/Components/CurrentPageMetaData.js
@@ -8,11 +8,13 @@ const CurrentPageMetaData = Scrivito.connect(() => {
   const htmlAttributes = { lang: 'en' };
   let title = '';
   let meta = [];
+  let canonical;
 
   const page = Scrivito.currentPage();
   if (page) {
     title = page.get('title') || '';
     meta = getMetaData(page);
+    canonical = <link rel='canonical' href={ Scrivito.urlFor(page) } />;
   }
 
   const links = [
@@ -28,7 +30,9 @@ const CurrentPageMetaData = Scrivito.connect(() => {
     htmlAttributes={ htmlAttributes }
     title={ title }
     link={ links }
-  />;
+  >
+    { canonical }
+  </Helmet>;
 });
 
 export default CurrentPageMetaData;


### PR DESCRIPTION
This PR includes the canonical tag for every page to the HTML head section.  `<link rel='canonical' href="https://my-website-url/my-canonical-page-path" />`. 

The canonical tag is important for SEO reasons to prevent the penalizing for duplicate content on the website from google. For further reading see: https://support.google.com/webmasters/answer/139066