### PR TITLE
Active useBuiltIns: "usage" for babel/preset-env webpack config

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,17 +1,8 @@
-import 'core-js/modules/es6.array.find';
-import 'core-js/modules/es6.array.from';
-import 'core-js/modules/es6.array.sort';
-import 'core-js/modules/es6.function.name';
+// Needed polyfills for React 16 for older browsers  +import './polyfills';
+// See https://reactjs.org/blog/2017/09/26/react-v16.0.html#javascript-environment-requirements
 import 'core-js/modules/es6.map';
-import 'core-js/modules/es6.object.assign';
-import 'core-js/modules/es6.object.set-prototype-of';
-import 'core-js/modules/es6.regexp.replace';
-import 'core-js/modules/es6.regexp.search';
-import 'core-js/modules/es6.regexp.split';
 import 'core-js/modules/es6.set';
-import 'core-js/modules/es6.string.includes';
-import 'core-js/modules/es6.string.starts-with';
+
+// Needed polyfill to support an iteratable
+// ObjSearch (https://www.scrivito.com/objsearch-aaa67c3157464d01)
 import 'core-js/modules/es6.symbol';
-import 'core-js/modules/es7.array.includes';
-import 'core-js/modules/es7.object.entries';
-import 'core-js/modules/web.dom.iterable';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,6 +93,7 @@ module.exports = (env = {}) => {
                     debug: false,
                     modules: false,
                     shippedProposals: true,
+                    useBuiltIns: 'usage',
                     targets: { browsers: ['last 2 versions'] },
                   }],
                 ],


### PR DESCRIPTION
This PR removes the explicit imports of polyfills and let babel handle the majority of polyfill imports. We have to add three polyfills by hand which have to be available at the initial loading of the website.

1. es6.map
2. es6.set
3. es6.symbol

The first two are needed by react 16 and the last one is important to support the iterator feature of scrivito `ObjSearch` (https://www.scrivito.com/objsearch-aaa67c3157464d01).
