### PR TITLE
Support Scrivito rate limit client verification

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,2 +1,2 @@
 /*
-Content-Security-Policy: base-uri 'none'; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' https://assets.scrivito.com https://www.google-analytics.com; object-src 'none'; block-all-mixed-content;
+Content-Security-Policy: base-uri 'none'; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' https://api.scrivito.com https://assets.scrivito.com https://www.google-analytics.com; object-src 'none'; block-all-mixed-content;


### PR DESCRIPTION
Allow the client verification via https://api.scrivito.com/javascripts/verification/hashcash.js