### PR TITLE
webpack dev server no longer recursively loads scrivito.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,7 +143,8 @@ module.exports = (env = {}) => {
       port: 8080,
       historyApiFallback: {
         rewrites: [
-          { from: /^\/scrivito/, to: '/scrivito/index.html' },
+          { from: /^\/scrivito$/, to: '/scrivito/index.html' },
+          { from: /^\/scrivito\//, to: '/scrivito/index.html' },
           { from: /./, to: '/index.html' },
         ],
       },


### PR DESCRIPTION
Reported by https://github.com/infopark/ip-friends/pull/3.