### PR TITLE
show widget section for medium sized headers

### DIFF
--- a/src/Components/Navigation/NavigationSection.js
+++ b/src/Components/Navigation/NavigationSection.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Scrivito from 'scrivito';
 
 function NavigationSection({ heightClassName }) {
-  if (heightClassName !== 'full-height') { return null; }
+  if (!['full-height', 'medium-height'].includes(heightClassName)) { return null; }
 
   if (!Scrivito.currentPage()) { return null; }
   const obj = Scrivito.currentPage();

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -671,10 +671,11 @@ footer {
   display: flex;
   min-height: 100vh;
 }
+.medium-height .container,
 .full-height .container {
   margin: auto !important;
 }
-
+.medium-height,
 .height-center {
   display: flex;
   text-align: center;
@@ -682,6 +683,9 @@ footer {
 .height-center .container {
   margin: auto !important;
 }
+
+/* nav section adaptions */
+section.navbar-fixed { padding-top: 80px; }
 
 /* navbar
 =================================================================== */


### PR DESCRIPTION
Allow medium sized headers to show the widget list.

![bildschirmfoto 2018-03-16 um 14 57 50](https://user-images.githubusercontent.com/579635/37524556-78f962d4-292a-11e8-896b-4ca698fc5f0b.png)

@agessler can you pls have a look if the design is good or what we can do to change the padding?