### PR TITLE
Less misleading description for publish date

### DIFF
--- a/src/Objs/BlogPost/BlogPostEditingConfig.js
+++ b/src/Objs/BlogPost/BlogPostEditingConfig.js
@@ -18,7 +18,7 @@ Scrivito.provideEditingConfig('BlogPost', {
     },
     publishedAt: {
       title: 'Published at',
-      description: 'When will this blog post be published?',
+      description: 'When was this blog post published?',
     },
     titleImage: {
       title: 'Header image',


### PR DESCRIPTION
The old description can be confused with a "valid from" date.