### PR TITLE
Use "lodash-es" instead of "lodash".

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8222,6 +8222,12 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
+      "integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA==",
+      "dev": true
+    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "inline-environment-variables-webpack-plugin": "^1.2.1",
     "is-empty": "^1.2.0",
     "jquery": "^3.3.1",
-    "lodash": "^4.17.5",
+    "lodash-es": "^4.17.8",
     "moment-from-now": "0.0.4",
     "node-sass": "^4.8.3",
     "progress-bar-webpack-plugin": "^1.11.0",

--- a/src/Components/BlogPost/BlogPostPreviewList.js
+++ b/src/Components/BlogPost/BlogPostPreviewList.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
-import truncate from 'lodash/truncate';
+import { truncate } from 'lodash-es';
 import BlogPostDate from './BlogPostDate';
 import formatDate from '../../utils/formatDate';
 import InPlaceEditingPlaceholder from '../InPlaceEditingPlaceholder';

--- a/src/Components/SchemaDotOrg.js
+++ b/src/Components/SchemaDotOrg.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
 import isEmpty from 'is-empty';
-import isPlainObject from 'lodash/isPlainObject';
+import { isPlainObject } from 'lodash-es';
 import dataFromAuthor from './SchemaDotOrg/dataFromAuthor';
 import dataFromEvent from './SchemaDotOrg/dataFromEvent';
 import dataFromJob from './SchemaDotOrg/dataFromJob';

--- a/src/Components/SchemaDotOrg/dataFromBlogPost.js
+++ b/src/Components/SchemaDotOrg/dataFromBlogPost.js
@@ -1,4 +1,4 @@
-import truncate from 'lodash/truncate';
+import { truncate } from 'lodash-es';
 import dataFromAuthor from './dataFromAuthor';
 import formatDate from '../../utils/formatDate';
 import urlFromBinary from '../../utils/urlFromBinary';

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import * as Scrivito from 'scrivito';
 import Draggable from 'react-draggable';
-import flatten from 'lodash/flatten';
-import isEqual from 'lodash/isEqual';
-import last from 'lodash/last';
-import take from 'lodash/take';
-import takeRight from 'lodash/takeRight';
-import times from 'lodash/times';
+import { flatten, isEqual, last, take, takeRight, times } from 'lodash-es';
 import ColumnWidget from '../../Widgets/ColumnWidget/ColumnWidgetClass';
 
 class ColumnsEditorTab extends React.Component {

--- a/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import take from 'lodash/take';
+import { take } from 'lodash-es';
 import fontAwesomeIcons from './fontAwesomeIcons';
 
 class AllIcons extends React.Component {

--- a/src/Objs/SearchResults/SearchResultItem.js
+++ b/src/Objs/SearchResults/SearchResultItem.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Scrivito from 'scrivito';
 import fromNow from 'moment-from-now';
 import Highlighter from 'react-highlight-words';
-import truncate from 'lodash/truncate';
+import { truncate } from 'lodash-es';
 import { textExtractFromObj } from '../../utils/textExtract';
 
 const PreviewImage = Scrivito.connect(({ item }) => {

--- a/src/Widgets/TestimonialWidget/TestimonialWidgetEditingConfig.js
+++ b/src/Widgets/TestimonialWidget/TestimonialWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import truncate from 'lodash/truncate';
+import { truncate } from 'lodash-es';
 
 Scrivito.provideEditingConfig('TestimonialWidget', {
   title: 'Testimonial',

--- a/src/utils/getMetaData.js
+++ b/src/utils/getMetaData.js
@@ -1,5 +1,5 @@
 import * as Scrivito from 'scrivito';
-import truncate from 'lodash/truncate';
+import { truncate } from 'lodash-es';
 import { textExtractFromObj } from './textExtract';
 import urlFromBinary from './urlFromBinary';
 


### PR DESCRIPTION
"lodash-es" supports tree shaking of webpack. So no more partial imports needed for lodash!

The filesize remains more or less the same.