### PR TITLE
Fix issues of SearchInput

### DIFF
--- a/src/Objs/SearchResults/SearchInput.js
+++ b/src/Objs/SearchResults/SearchInput.js
@@ -6,18 +6,7 @@ class SearchInput extends React.Component {
     super(props);
 
     this.state = {
-      q: props.params.q,
-    };
-  }
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const prevPropsQ = prevState.prevPropsQ;
-    const nextPropsQ = nextProps.params && nextProps.params.q;
-    if (prevPropsQ === nextPropsQ) { return null; }
-
-    return {
-      prevPropsQ: nextPropsQ,
-      q: nextPropsQ,
+      q: props.params.q || '',
     };
   }
 


### PR DESCRIPTION
This change fixes 2 potential issues:

1. An undefined value may trigger a controlled/uncontrolled console warning.
2. The implementation of `getDerivedStateFromProps` may revert user input on updates. AFAICS it's not needed at all.