### PR TITLE
Changed text-align of links in nav

### DIFF
--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1069,6 +1069,7 @@ section.navbar-fixed { padding-top: 80px; }
     font-size: 24px;
     text-transform: none;
     border-top: 1px solid #eee;
+    text-align: left;
   }
   .nav > li:first-child > a {
     border: 0;


### PR DESCRIPTION
https://trello.com/c/QkmEwbJn/340-navigation-on-mobile-for-pages-without-path-look-different

`navbar-nav` object inherits text-align from `medium-height` element, added specific `text-align` value for links in the nav