### PR TITLE
Minimize build with Terser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,6 +1246,91 @@
         "long": "^3.2.0"
       }
     },
+    "@webpack-contrib/schema-utils": {
+      "version": "1.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz",
+      "integrity": "sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==",
+      "requires": {
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0",
+        "chalk": "^2.3.2",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0",
+        "webpack-log": "^1.1.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -4019,6 +4104,11 @@
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
+    },
+    "figgy-pudding": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.2.0.tgz",
+      "integrity": "sha512-S2gSvqcqkI4sk+dI3ykKllfEg88dL5cXM0QPT4z9UbOkNygqec8/99d0VB3ikZ7u1/QC5l4e1YJPWvoUFuRVkg=="
     },
     "figures": {
       "version": "2.0.0",
@@ -9485,6 +9575,181 @@
         "tcomb": "^3.0.0"
       }
     },
+    "terser": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.8.1.tgz",
+      "integrity": "sha512-FRin3gKQ0vm0xPPLuxw1FqpVgv1b2pBpYCaFb5qe6A7sD749Fnq1VbDiX3CEFM0BV0fqDzFtBfgmxhxCdzKQIg==",
+      "requires": {
+        "commander": "~2.16.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.6"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+          "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.0.0.tgz",
+      "integrity": "sha512-J1i69VN1tyhzpzbWrNvNaS1G4G7iNCvTvoT+qGNFxQPqND2Kk49M6yKw5/yA+dcU0D5pH/PuuH2ouDbhqDf0RQ==",
+      "requires": {
+        "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
+        "cacache": "^11.0.2",
+        "find-cache-dir": "^2.0.0",
+        "serialize-javascript": "^1.4.0",
+        "source-map": "^0.6.1",
+        "terser": "^3.8.1",
+        "webpack-sources": "^1.1.0",
+        "worker-farm": "^1.5.2"
+      },
+      "dependencies": {
+        "cacache": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
+          "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
+          "requires": {
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "figgy-pudding": "^3.1.0",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.3",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.0",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
+          }
+        },
+        "find-cache-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+          "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+          "requires": {
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "ssri": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.0.tgz",
+          "integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA=="
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9686,9 +9951,9 @@
       }
     },
     "uglifyjs-webpack-plugin": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz",
-      "integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz",
+      "integrity": "sha512-1VicfKhCYHLS8m1DCApqBhoulnASsEoJ/BvpUpP4zoNAPpKzdH+ghk0olGJMmwX2/jprK2j3hAHdUbczBSy2FA==",
       "requires": {
         "cacache": "^10.0.4",
         "find-cache-dir": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "scrivito": "^1.2.0",
     "slick-carousel": "^1.6.0",
     "striptags": "^2.2.1",
-    "uglifyjs-webpack-plugin": "^1.2.5",
+    "terser-webpack-plugin": "^1.0.0",
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",
     "webpack-dev-server": "^3.1.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,25 +1,28 @@
-const dotenv = require('dotenv');
-const path = require('path');
-const process = require('process');
-const webpack = require('webpack');
-const CleanWebpackPlugin = require('clean-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const ProgressBarPlugin = require('progress-bar-webpack-plugin');
-const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
-const ZipPlugin = require('zip-webpack-plugin');
-const AddSitemapToRedirectsWebpackPlugin = require('./add-sitemap-to-redirects-webpack-plugin');
+const dotenv = require("dotenv");
+const path = require("path");
+const process = require("process");
+const webpack = require("webpack");
+const CleanWebpackPlugin = require("clean-webpack-plugin");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
+const ProgressBarPlugin = require("progress-bar-webpack-plugin");
+const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
+const ZipPlugin = require("zip-webpack-plugin");
+const AddSitemapToRedirectsWebpackPlugin = require("./add-sitemap-to-redirects-webpack-plugin");
 
 // load ".env"
 dotenv.config();
 
-const buildPath = 'build';
+const buildPath = "build";
 
 module.exports = (env = {}) => {
   // see https://github.com/webpack/webpack/issues/2537 for details
-  const isProduction = process.argv.indexOf('-p') !== -1 || env.production;
+  const isProduction = process.argv.indexOf("-p") !== -1 || env.production;
 
-  if (!process.env.SCRIVITO_TENANT || process.env.SCRIVITO_TENANT === 'your_scrivito_tenant_id') {
+  if (
+    !process.env.SCRIVITO_TENANT ||
+    process.env.SCRIVITO_TENANT === "your_scrivito_tenant_id"
+  ) {
     throw 'Environment variable "SCRIVITO_TENANT" is not defined!' +
       ' Check if the ".env" file with a proper SCRIVITO_TENANT is set.' +
       ' See ".env.example" for an example.';
@@ -28,16 +31,19 @@ module.exports = (env = {}) => {
   const plugins = [
     new ProgressBarPlugin(),
     new webpack.EnvironmentPlugin({
-      NODE_ENV: isProduction ? 'production' : 'development',
-      SCRIVITO_TENANT: '',
+      NODE_ENV: isProduction ? "production" : "development",
+      SCRIVITO_TENANT: "",
     }),
     new CopyWebpackPlugin([
-      { from: '../public' },
-      { from: '../node_modules/scrivito/scrivito/index.html', to: 'scrivito/index.html' },
+      { from: "../public" },
+      {
+        from: "../node_modules/scrivito/scrivito/index.html",
+        to: "scrivito/index.html",
+      },
     ]),
     new AddSitemapToRedirectsWebpackPlugin(),
     new ExtractTextPlugin({
-      filename: '[name]',
+      filename: "[name]",
     }),
     new webpack.optimize.ModuleConcatenationPlugin(),
   ];
@@ -54,9 +60,9 @@ module.exports = (env = {}) => {
         },
       }),
       new ZipPlugin({
-        filename: 'build.zip',
-        path: '../',
-        pathPrefix: 'build/',
+        filename: "build.zip",
+        path: "../",
+        pathPrefix: "build/",
       })
     );
   } else {
@@ -64,38 +70,41 @@ module.exports = (env = {}) => {
   }
 
   return {
-    mode: isProduction ? 'production' : 'development',
-    context: path.join(__dirname, 'src'),
+    mode: isProduction ? "production" : "development",
+    context: path.join(__dirname, "src"),
     entry: {
-      index: './index.js',
-      google_analytics: './google_analytics.js',
-      scrivito_extensions: './scrivito_extensions.js',
-      sitemap: './sitemap.js',
-      'index.css': './assets/stylesheets/index.scss',
+      index: "./index.js",
+      google_analytics: "./google_analytics.js",
+      scrivito_extensions: "./scrivito_extensions.js",
+      sitemap: "./sitemap.js",
+      "index.css": "./assets/stylesheets/index.scss",
     },
     module: {
       rules: [
         {
           test: /\.js$/,
-          include: [path.join(__dirname, 'src'), path.join(__dirname, 'node_modules/autotrack')],
+          include: [
+            path.join(__dirname, "src"),
+            path.join(__dirname, "node_modules/autotrack"),
+          ],
           use: [
             {
-              loader: 'babel-loader',
+              loader: "babel-loader",
               options: {
                 presets: [
-                  '@babel/preset-react',
+                  "@babel/preset-react",
                   [
-                    '@babel/preset-env',
+                    "@babel/preset-env",
                     {
                       debug: false,
                       modules: false,
                       shippedProposals: true,
-                      useBuiltIns: 'usage',
-                      targets: { browsers: ['last 2 versions'] },
+                      useBuiltIns: "usage",
+                      targets: { browsers: ["last 2 versions"] },
                     },
                   ],
                 ],
-                cacheDirectory: 'tmp/babel-cache',
+                cacheDirectory: "tmp/babel-cache",
               },
             },
           ],
@@ -105,13 +114,13 @@ module.exports = (env = {}) => {
           use: ExtractTextPlugin.extract({
             use: [
               {
-                loader: 'css-loader',
+                loader: "css-loader",
                 options: {
                   minimize: isProduction,
                 },
               },
               {
-                loader: 'sass-loader',
+                loader: "sass-loader",
               },
             ],
           }),
@@ -120,9 +129,9 @@ module.exports = (env = {}) => {
           test: /\.(jpg|png|eot|svg|ttf|woff|woff2|gif|html)$/,
           use: [
             {
-              loader: 'file-loader',
+              loader: "file-loader",
               options: {
-                name: '[name].[hash].[ext]',
+                name: "[name].[hash].[ext]",
               },
             },
           ],
@@ -130,26 +139,26 @@ module.exports = (env = {}) => {
       ],
     },
     output: {
-      publicPath: '/',
-      filename: '[name].js',
+      publicPath: "/",
+      filename: "[name].js",
       path: path.join(__dirname, buildPath),
     },
     plugins,
     resolve: {
-      extensions: ['.js'],
-      modules: ['node_modules'],
+      extensions: [".js"],
+      modules: ["node_modules"],
     },
     devServer: {
       port: 8080,
       historyApiFallback: {
         rewrites: [
-          { from: /^\/scrivito$/, to: '/scrivito/index.html' },
-          { from: /^\/scrivito\//, to: '/scrivito/index.html' },
-          { from: /./, to: '/index.html' },
+          { from: /^\/scrivito$/, to: "/scrivito/index.html" },
+          { from: /^\/scrivito\//, to: "/scrivito/index.html" },
+          { from: /./, to: "/index.html" },
         ],
       },
       headers: {
-        'Access-Control-Allow-Origin': '*',
+        "Access-Control-Allow-Origin": "*",
       },
     },
   };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const ProgressBarPlugin = require("progress-bar-webpack-plugin");
-const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
 const ZipPlugin = require("zip-webpack-plugin");
 const AddSitemapToRedirectsWebpackPlugin = require("./add-sitemap-to-redirects-webpack-plugin");
 
@@ -51,14 +51,6 @@ module.exports = (env = {}) => {
   if (isProduction) {
     plugins.unshift(new CleanWebpackPlugin([buildPath], { verbose: false }));
     plugins.push(
-      new UglifyJSPlugin({
-        cache: true,
-        parallel: true,
-        uglifyOptions: {
-          ie8: false,
-          ecma: 5,
-        },
-      }),
       new ZipPlugin({
         filename: "build.zip",
         path: "../",
@@ -136,6 +128,15 @@ module.exports = (env = {}) => {
             },
           ],
         },
+      ],
+    },
+    optimization: {
+      minimizer: [
+        new TerserPlugin({
+          cache: true,
+          parallel: true,
+          terserOptions: { ecma: 5 },
+        }),
       ],
     },
     output: {


### PR DESCRIPTION
With the current setup a production build may suffer from issues of `uglify-es`, which is no longer maintained.

https://github.com/webpack-contrib/terser-webpack-plugin uses Terser, which is more up-to-date, and replaces uglify-es.

Sorry for typos 😜 