### PR TITLE
Striptags 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9471,9 +9471,9 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "striptags": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
-      "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sass-loader": "^7.0.3",
     "scrivito": "^1.2.0",
     "slick-carousel": "^1.6.0",
-    "striptags": "^2.2.1",
+    "striptags": "^3.1.1",
     "terser-webpack-plugin": "^1.0.0",
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,6 +78,7 @@ module.exports = (env = {}) => {
           include: [
             path.join(__dirname, "src"),
             path.join(__dirname, "node_modules/autotrack"),
+            path.join(__dirname, "node_modules/striptags"),
           ],
           use: [
             {
@@ -95,6 +96,12 @@ module.exports = (env = {}) => {
                       targets: { browsers: ["last 2 versions"] },
                     },
                   ],
+                ],
+                overrides: [
+                  {
+                    test: ["./node_modules/striptags"],
+                    presets: [["@babel/preset-env", { useBuiltIns: false }]],
+                  },
                 ],
                 cacheDirectory: "tmp/babel-cache",
               },


### PR DESCRIPTION
Use the latest version of `striptags`. It needs to be compiled by babel, but should *not* be enriched with polyfills, since that will break webpack with the following message:

```
"export 'default' (imported as 'striptags') was not found in 'striptags'
 @ ./utils/textExtract.js
 @ ./Objs/SearchResults/SearchResultItem.js
 @ ./Objs sync \.js$
 @ ./Objs/index.js
 @ ./sitemap.js
```

Thanks to the [`overrides`](https://babeljs.io/blog/2018/06/26/on-consuming-and-publishing-es2015+-packages#selective-compilation-with-overrides) option it is possible to disable the given `@babel/preset-env` rule.