### PR TITLE
Better CSP Placeholder

### DIFF
--- a/extend-csp-headers-webpack-plugin.js
+++ b/extend-csp-headers-webpack-plugin.js
@@ -27,12 +27,12 @@ function generateCsp(assets) {
   const headersCsp = assets["_headers_csp.json"].source().toString();
   delete assets["_headers_csp.json"];
   const directives = JSON.parse(headersCsp);
-  return `Content-Security-Policy: ${builder({ directives })}`;
+  return builder({ directives });
 }
 
 function extendHeaders(assets, csp) {
   const headers = assets._headers.source().toString();
-  const CSP_PLACEHOLDER = "Content-Security-Policy-PLACEHOLDER;";
+  const CSP_PLACEHOLDER = "CSP-DIRECTIVES-PLACEHOLDER;";
   if (!headers.includes(CSP_PLACEHOLDER)) {
     throw new Error(
       `_headers doesn't contain '${CSP_PLACEHOLDER}'. Please add the placeholder.`

--- a/public/_headers
+++ b/public/_headers
@@ -3,5 +3,5 @@
 ##
 
 /*
-# Content-Security-Policy-PLACEHOLDER will be replaced by ExtendCspHeadersWebpackPlugin
-Content-Security-Policy-PLACEHOLDER;
+# CSP-DIRECTIVES-PLACEHOLDER will be replaced by ExtendCspHeadersWebpackPlugin
+Content-Security-Policy: CSP-DIRECTIVES-PLACEHOLDER;

--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,9 @@
 ##
 # Netlify headers. See https://www.netlify.com/docs/headers-and-basic-auth/ for details.
+#
+# CSP-DIRECTIVES-PLACEHOLDER will be replaced by ExtendCspHeadersWebpackPlugin,
+# which uses _headers_csp.json as input.
 ##
 
 /*
-# CSP-DIRECTIVES-PLACEHOLDER will be replaced by ExtendCspHeadersWebpackPlugin
-Content-Security-Policy: CSP-DIRECTIVES-PLACEHOLDER;
+  Content-Security-Policy: CSP-DIRECTIVES-PLACEHOLDER;

--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,7 @@
+##
+# Netlify headers. See https://www.netlify.com/docs/headers-and-basic-auth/ for details.
+##
+
 /*
 # Content-Security-Policy-PLACEHOLDER will be replaced by ExtendCspHeadersWebpackPlugin
 Content-Security-Policy-PLACEHOLDER;


### PR DESCRIPTION
It is now up to `_headers` to decide how the header should be named. With that it should be easier to change `Content-Security-Policy` to `Content-Security-Policy-Report-Only`.

Follow-up of https://github.com/Scrivito/scrivito_example_app_js/pull/97.