### PR TITLE
Use navigateTo for internal links

### DIFF
--- a/src/Objs/Redirect/RedirectComponent.js
+++ b/src/Objs/Redirect/RedirectComponent.js
@@ -21,7 +21,7 @@ class RedirectComponent extends React.Component {
         const scrivitoUiUrl = url.replace(/(\/\/[^/]+)/, "$1/scrivito");
         window.top.location.replace(scrivitoUiUrl);
       } else {
-        window.location.replace(url);
+        Scrivito.navigateTo(link);
       }
     });
   }

--- a/src/Objs/Redirect/RedirectComponent.js
+++ b/src/Objs/Redirect/RedirectComponent.js
@@ -15,9 +15,7 @@ class RedirectComponent extends React.Component {
         return;
       }
 
-      if (link.isExternal()) {
-        window.top.location.replace(url);
-      } else if (openInUi === "yes") {
+      if (link.isInternal() && openInUi === "yes") {
         const scrivitoUiUrl = url.replace(/(\/\/[^/]+)/, "$1/scrivito");
         window.top.location.replace(scrivitoUiUrl);
       } else {


### PR DESCRIPTION
Redirects an internal link a more soft way, keeping the single page app loaded.

How to check:

Open Example App in UI
Switch to Editing
Open ContentBrowser
Search `Redirect`
Select first Page `Redirect` (remember its `id`, if necessary).
Switch off `openInUi`

Finally: provide a `hash` to the link (beyond capabilities of current UI)
```
// enter application frame first
Scrivito.load(() => Scrivito.getClass('Redirect').all().take(1));
obj = Scrivito.getClass('Redirect').all().take(1)[0];
newLink = obj.get('link').copy({ hash: 'gohere' }):
obj.update({ link: newLink });
```

Then click `/scrivito` on the homepage and see the `#gohere` be appended to the address bar.