### PR TITLE
Redirect to 404 only if the application is run top-level

### DIFF
--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -4,10 +4,12 @@ import Helmet from "react-helmet";
 
 class NotFoundErrorPage extends React.Component {
   componentDidMount() {
-    const path = window.location.pathname;
+    if (window === window.parent) {
+      const path = window.location.pathname;
 
-    if (path !== "/404") {
-      window.location.replace(`/404?path=${encodeURIComponent(path)}`);
+      if (path !== "/404") {
+        window.location.replace(`/404?path=${encodeURIComponent(path)}`);
+      }
     }
   }
 


### PR DESCRIPTION
The intended use is to respond a correct http status code to the
browser / crawler. But to force-redirect to a different page within
a UI context is currently better avoided.

Background: With the technical changes of 1.4.0, the application auto-detects a change of the current page (for working copies). This includes that the application detects whether the page has been removed by someone else. The UI gets upset if the following re-render destroys the application frame, which it currently does because of the forced redirect.

Unfortunately, there is no API to detect whether a UI is present, therefore it we use an educated guess which clearly avoids the redirect if a UI is present. It avoids the redirect too for every other case where the application is not rendered at `window.top` level, which may be reasonable or not (if reasonable, one would have to identify the UI more clearly, e.g. whether `window.top.location.pathname` starts with `/scrivito/`).