### PR TITLE
Changed take(1) on first()

### DIFF
--- a/src/Components/BlogPost/BlogPostNavigation.js
+++ b/src/Components/BlogPost/BlogPostNavigation.js
@@ -34,7 +34,7 @@ const BlogPostNextLink = Scrivito.connect(({ currentBlogPost }) => {
   const currentDate = currentBlogPost.get("publishedAt");
 
   // find greater than publishedAt
-  const [newerPost] = Scrivito.getClass("BlogPost")
+  const newerPost = Scrivito.getClass("BlogPost")
     .where("publishedAt", "isGreaterThan", currentDate)
     .order("publishedAt", "asc")
     .first();
@@ -54,7 +54,7 @@ const BlogPostPreviousLink = Scrivito.connect(({ currentBlogPost }) => {
   const currentDate = currentBlogPost.get("publishedAt");
 
   // find less than or equal publishedAt
-  const [olderPost] = Scrivito.getClass("BlogPost")
+  const olderPost = Scrivito.getClass("BlogPost")
     .all()
     .andNot("id", "equals", currentBlogPost.id())
     .andNot("publishedAt", "isGreaterThan", currentDate)

--- a/src/Components/BlogPost/BlogPostNavigation.js
+++ b/src/Components/BlogPost/BlogPostNavigation.js
@@ -37,7 +37,7 @@ const BlogPostNextLink = Scrivito.connect(({ currentBlogPost }) => {
   const [newerPost] = Scrivito.getClass("BlogPost")
     .where("publishedAt", "isGreaterThan", currentDate)
     .order("publishedAt", "asc")
-    .take(1);
+    .first();
 
   if (!newerPost) {
     return null;
@@ -59,7 +59,7 @@ const BlogPostPreviousLink = Scrivito.connect(({ currentBlogPost }) => {
     .andNot("id", "equals", currentBlogPost.id())
     .andNot("publishedAt", "isGreaterThan", currentDate)
     .order("publishedAt", "desc")
-    .take(1);
+    .first();
 
   if (!olderPost) {
     return null;

--- a/src/Components/Navigation/Search.js
+++ b/src/Components/Navigation/Search.js
@@ -70,7 +70,7 @@ const SearchBox = Scrivito.connect(
 function oldestSearchResultsPage() {
   return Scrivito.Obj.where("_objClass", "equals", "SearchResults")
     .order("_createdAt")
-    .take(1)[0];
+    .first()[0];
 }
 
 function SearchIcon({ toggleSearch }) {

--- a/src/Components/Navigation/Search.js
+++ b/src/Components/Navigation/Search.js
@@ -70,7 +70,7 @@ const SearchBox = Scrivito.connect(
 function oldestSearchResultsPage() {
   return Scrivito.Obj.where("_objClass", "equals", "SearchResults")
     .order("_createdAt")
-    .first()[0];
+    .first();
 }
 
 function SearchIcon({ toggleSearch }) {


### PR DESCRIPTION
https://trello.com/c/G50MIOcA/384-replace-take1-with-first

Changed method `take(1)` on `first()` according to new scrivito version (1.3.0).
See documentation for `first()` method -> https://www.scrivito.com/js-sdk/ObjSearch-first