### PR TITLE
Fixed typo in header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
 
 /*
   Content-Security-Policy: CSP-DIRECTIVES-PLACEHOLDER;
-  X-frame-options: sameorigin
+  X-Frame-Options: sameorigin
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
Fixed typo in `_headers` file