### PR TITLE
Bugfix: Autoreloading works again

### DIFF
--- a/AddSitemapToRedirectsWebpackPlugin.js
+++ b/AddSitemapToRedirectsWebpackPlugin.js
@@ -1,26 +1,33 @@
 function AddSitemapToRedirectsWebpackPlugin() {
   return {
-    apply: (compiler) => {
-      compiler.hooks.emit.tapAsync('AddSitemapToRedirectsWebpackPlugin', emit);
+    apply: compiler => {
+      compiler.hooks.emit.tapPromise(
+        "AddSitemapToRedirectsWebpackPlugin",
+        emit
+      );
     },
   };
 }
 
-function emit(compilation, callback) {
-  const tenant = process.env.SCRIVITO_TENANT;
-  const url = process.env.URL;
+function emit(compilation) {
+  return new Promise(resolve => {
+    const tenant = process.env.SCRIVITO_TENANT;
+    const url = process.env.URL;
 
-  if (url && tenant) {
-    const previousRedirects = compilation.assets['_redirects'].source().toString();
-    const redirects = addSitemapToRedirects(tenant, url, previousRedirects);
+    if (url && tenant) {
+      const previousRedirects = compilation.assets["_redirects"]
+        .source()
+        .toString();
+      const redirects = addSitemapToRedirects(tenant, url, previousRedirects);
 
-    compilation.assets['_redirects'] = {
-      source: () => redirects,
-      size: () => redirects.length,
-    };
-  }
+      compilation.assets["_redirects"] = {
+        source: () => redirects,
+        size: () => redirects.length,
+      };
+    }
 
-  callback();
+    resolve();
+  });
 }
 
 function addSitemapToRedirects(tenant, url, previousRedirects) {

--- a/ExtendCspHeadersWebpackPlugin.js
+++ b/ExtendCspHeadersWebpackPlugin.js
@@ -12,15 +12,17 @@ const builder = require("content-security-policy-builder");
 function ExtendCspHeadersWebpackPlugin() {
   return {
     apply: compiler => {
-      compiler.hooks.emit.tapAsync("ExtendCspHeadersWebpackPlugin", emit);
+      compiler.hooks.emit.tapPromise("ExtendCspHeadersWebpackPlugin", emit);
     },
   };
 }
 
-function emit(compilation, callback) {
-  const csp = generateCsp(compilation.assets);
-  extendHeaders(compilation.assets, csp);
-  callback();
+function emit(compilation) {
+  return new Promise(resolve => {
+    const csp = generateCsp(compilation.assets);
+    extendHeaders(compilation.assets, csp);
+    resolve();
+  });
 }
 
 function generateCsp(assets) {

--- a/ExtendCspHeadersWebpackPlugin.js
+++ b/ExtendCspHeadersWebpackPlugin.js
@@ -19,9 +19,13 @@ function ExtendCspHeadersWebpackPlugin() {
 
 function emit(compilation) {
   return new Promise(resolve => {
-    const csp = generateCsp(compilation.assets);
-    extendHeaders(compilation.assets, csp);
-    resolve();
+    const assets = compilation.assets;
+    if (!assets["_headers"] || !assets["_headersCsp.json"]) {
+      return resolve();
+    }
+    const csp = generateCsp(assets);
+    extendHeaders(assets, csp);
+    return resolve();
   });
 }
 
@@ -33,7 +37,7 @@ function generateCsp(assets) {
 }
 
 function extendHeaders(assets, csp) {
-  const headers = assets._headers.source().toString();
+  const headers = assets["_headers"].source().toString();
   const CSP_PLACEHOLDER = "CSP-DIRECTIVES-PLACEHOLDER;";
   if (!headers.includes(CSP_PLACEHOLDER)) {
     throw new Error(
@@ -43,7 +47,7 @@ function extendHeaders(assets, csp) {
 
   const modifiedHeaders = headers.replace(CSP_PLACEHOLDER, csp);
 
-  assets._headers = {
+  assets["_headers"] = {
     source: () => modifiedHeaders,
     size: () => modifiedHeaders.length,
   };


### PR DESCRIPTION
Since the introduction of `ExtendCspHeadersWebpackPlugin` `npm start` blocks on auto recompile.

This PR does two thinks:

* Switch from `tapAsync` to `tapPromise` because it helps better to surface errors.
* Skip `ExtendCspHeadersWebpackPlugin` if `_headers` or `_headersCsp.json` is missing. This is for example the case during a auto recompile, when running `webpack-dev-server`.