### PR TITLE
CSP: No more "unsafe-inline" for default. Instead only us it for style-src

### DIFF
--- a/public/_headersCsp.json
+++ b/public/_headersCsp.json
@@ -1,6 +1,7 @@
 {
   "base-uri": "'none'",
-  "default-src": ["'self'", "'unsafe-inline'", "data:", "https:", "wss:"],
+  "default-src": ["'self'", "data:", "https:", "wss:"],
+  "style-src": ["'self'", "data:", "https:", "wss:", "'unsafe-inline'"],
   "script-src": [
     "'self'",
     "https://api.scrivito.com",


### PR DESCRIPTION
"unsafe-inline" is needed for style-src, so that for example animations of `react-reveal` can work. Also our BackgroundImageTag AFAIK does use inline styles.

This gives us a `A+` rating on securityheaders.com:
<img width="1214" alt="a headers" src="https://user-images.githubusercontent.com/86275/45884113-3cb39d80-bdb3-11e8-90f4-438eea20079d.png">