### PR TITLE
Redirect obj bugfix

### DIFF
--- a/src/Objs/Redirect/RedirectComponent.js
+++ b/src/Objs/Redirect/RedirectComponent.js
@@ -21,7 +21,7 @@ class RedirectComponent extends React.Component {
         const scrivitoUiUrl = url.replace(/(\/\/[^/]+)/, "$1/scrivito");
         window.top.location.replace(scrivitoUiUrl);
       } else {
-        Scrivito.navigateTo(link);
+        window.location.replace(url);
       }
     });
   }

--- a/src/Objs/Redirect/RedirectComponent.js
+++ b/src/Objs/Redirect/RedirectComponent.js
@@ -15,7 +15,9 @@ class RedirectComponent extends React.Component {
         return;
       }
 
-      if (link.isInternal() && openInUi === "yes") {
+      if (link.isExternal()) {
+        window.top.location.replace(url);
+      } else if (openInUi === "yes") {
         const scrivitoUiUrl = url.replace(/(\/\/[^/]+)/, "$1/scrivito");
         window.top.location.replace(scrivitoUiUrl);
       } else {

--- a/src/Objs/Redirect/RedirectEditingConfig.js
+++ b/src/Objs/Redirect/RedirectEditingConfig.js
@@ -6,6 +6,10 @@ Scrivito.provideEditingConfig("Redirect", {
   thumbnail: redirectObjIcon,
   hideInSelectionDialogs: true,
   attributes: {
+    title: {
+      title: "Title",
+      description: "Limit to 55 characters.",
+    },
     link: {
       title: "Link",
     },
@@ -15,7 +19,7 @@ Scrivito.provideEditingConfig("Redirect", {
       values: [{ value: "yes", title: "Yes" }, { value: "no", title: "No" }],
     },
   },
-  properties: ["link", "openInUi"],
+  properties: ["title", "link", "openInUi"],
   initialContent: {
     openInUi: "no",
   },

--- a/src/Objs/Redirect/RedirectObjClass.js
+++ b/src/Objs/Redirect/RedirectObjClass.js
@@ -2,6 +2,7 @@ import * as Scrivito from "scrivito";
 
 const Redirect = Scrivito.provideObjClass("Redirect", {
   attributes: {
+    title: "string",
     link: "link",
     openInUi: ["enum", { values: ["yes", "no"] }],
   },


### PR DESCRIPTION
This PR reverts https://github.com/Scrivito/scrivito_example_app_js/pull/105. `Scrivito.navigateTo` is not good enough in this case, because it does do a browser location push instead of a replace. This means, that a "navigate back click" does bring you back to the redirect obj, which then will redirect you again - quite annoying and also noticed by our customers.

This PR also includes two improvements for Redirect Objs:

* ~~When in edit mode the redirect does not take place. This allows the editor to change page properties of a redirect without having to go to the Content Browser.~~ **EDIT**: Did remove the functionality for now.
* A redirect obj now also has a title. This is useful, if someone includes the redirect obj in the navigation. Then it should be possible to edit the title.