### PR TITLE
Yeoman generator - changed order of render methods

### DIFF
--- a/generator-scrivito/generators/obj/index.js
+++ b/generator-scrivito/generators/obj/index.js
@@ -28,8 +28,8 @@ module.exports = class extends Generator {
       const folder = `src/Objs/${objClassName}`;
       const humanFriendlyName = lodash.startCase(objClassName);
       this._generateFile(
-        "XComponent.js.ejs",
-        `${folder}/${objClassName}Component.js`,
+        "XObjClass.js.ejs",
+        `${folder}/${objClassName}ObjClass.js`,
         { objClassName }
       );
       this._generateFile(
@@ -38,8 +38,8 @@ module.exports = class extends Generator {
         { objClassName, humanFriendlyName }
       );
       this._generateFile(
-        "XObjClass.js.ejs",
-        `${folder}/${objClassName}ObjClass.js`,
+        "XComponent.js.ejs",
+        `${folder}/${objClassName}Component.js`,
         { objClassName }
       );
       this.registerTransformStream(gulpPrettier());

--- a/generator-scrivito/generators/widget/index.js
+++ b/generator-scrivito/generators/widget/index.js
@@ -30,8 +30,8 @@ module.exports = class extends Generator {
         widgetClassName.replace(/Widget$/, "")
       );
       this._generateFile(
-        "XWidgetComponent.js.ejs",
-        `${folder}/${widgetClassName}Component.js`,
+        "XWidgetClass.js.ejs",
+        `${folder}/${widgetClassName}Class.js`,
         { widgetClassName }
       );
       this._generateFile(
@@ -40,8 +40,8 @@ module.exports = class extends Generator {
         { widgetClassName, humanFriendlyName }
       );
       this._generateFile(
-        "XWidgetClass.js.ejs",
-        `${folder}/${widgetClassName}Class.js`,
+        "XWidgetComponent.js.ejs",
+        `${folder}/${widgetClassName}Component.js`,
         { widgetClassName }
       );
       this.registerTransformStream(gulpPrettier());


### PR DESCRIPTION
According Andreas feedback this PR's changing order of calling render methods.

**Order consistent with documentation:**
`create src/Widgets/TitleWidget/TitleWidgetClass.js`
`create src/Widgets/TitleWidget/TitleWidgetEditingConfig.js`
`create src/Widgets/TitleWidget/TitleWidgetComponent.js`