### PR TITLE
Changed the description for link attribute in the image widget

### DIFF
--- a/src/Widgets/ImageWidget/ImageWidgetEditingConfig.js
+++ b/src/Widgets/ImageWidget/ImageWidgetEditingConfig.js
@@ -22,7 +22,7 @@ Scrivito.provideEditingConfig("ImageWidget", {
     },
     link: {
       title: "Link (optional)",
-      description: "The link where this image should lead.",
+      description: "The page to open after clicking the image.",
     },
     animation: {
       title: "Animation",


### PR DESCRIPTION
The description for the link attribute in image widget is different now according to Andreas feedback. 
`The link where this image should lead.` -> `The page to open after clicking the image.`