### PR TITLE
Prerender security

### DIFF
--- a/storePrerenderedContent.js
+++ b/storePrerenderedContent.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const fse = require("fs-extra");
+const path = require("path");
 const puppeteer = require("puppeteer");
 
 const TARGET_DIR = "buildPrerendered";
@@ -81,8 +82,16 @@ function startServer() {
 
 function storeResults(results) {
   results.forEach(({ fileName, fileContent }) => {
-    console.log(`  [storeResults] Storing ${fileName}...`);
-    fse.outputFileSync(`${TARGET_DIR}/${fileName}`, fileContent);
+    const filePath = path.join(TARGET_DIR, fileName);
+    if (!filePath.startsWith(`${TARGET_DIR}`)) {
+      console.log(
+        `  [storeResults] ❌ fileName "${fileName}" is invalid! Skipping file.`
+      );
+      return;
+    }
+
+    console.log(`  [storeResults] Storing "${fileName}"...`);
+    fse.outputFileSync(filePath, fileContent);
   });
 }
 

--- a/storePrerenderedContent.js
+++ b/storePrerenderedContent.js
@@ -83,7 +83,7 @@ function startServer() {
 function storeResults(results) {
   results.forEach(({ fileName, fileContent }) => {
     const filePath = path.join(TARGET_DIR, fileName);
-    if (!filePath.startsWith(`${TARGET_DIR}`)) {
+    if (!path.normalize(filePath).startsWith(`${TARGET_DIR}`)) {
       logStoreResults(`❌ fileName "${fileName}" is invalid! Skipping file...`);
       return;
     }

--- a/storePrerenderedContent.js
+++ b/storePrerenderedContent.js
@@ -84,13 +84,17 @@ function storeResults(results) {
   results.forEach(({ fileName, fileContent }) => {
     const filePath = path.join(TARGET_DIR, fileName);
     if (!filePath.startsWith(`${TARGET_DIR}`)) {
-      console.log(
-        `  [storeResults] ❌ fileName "${fileName}" is invalid! Skipping file.`
+      logStoreResults(`❌ fileName "${fileName}" is invalid! Skipping file...`);
+      return;
+    }
+    if (fse.existsSync(filePath)) {
+      logStoreResults(
+        `❌ fileName "${fileName}" already exists in build! Skipping file...`
       );
       return;
     }
 
-    console.log(`  [storeResults] Storing "${fileName}"...`);
+    logStoreResults(`Storing "${fileName}"...`);
     fse.outputFileSync(filePath, fileContent);
   });
 }
@@ -101,6 +105,10 @@ function log(message, ...args) {
 
 function logBrowser(message, ...args) {
   console.log(`  [executeInBrowser] 🖥️️  ${message}`, ...args);
+}
+
+function logStoreResults(message, ...args) {
+  console.log(`  [storeResults] ${message}`, ...args);
 }
 
 storePrerenderedContent().catch(e => {


### PR DESCRIPTION
Given the following `rerenderContent`:

```js
function prerenderContent() {
  return new Promise(resolve => {
    resolve([
      { fileName: "../bad.html", fileContent: "should not be there" },
      { fileName: "/good.html", fileContent: "isFine" },
      { fileName: "/also/good.html", fileContent: "isFineToo" },
      { fileName: "google_analytics.js", fileContent: "OVERWRITE!!" },
    ]);
  });
}
```

The file `bad.html` should not be stored, since it could "escape" the `TARGET_DIR`. Also `google_analytics.js` should not be overwritten, since it already exists in `build/`.

If one of the two cases is detected, it is not stored and a warning is logged. I'm not sure, if we should fail the build, if this happens.