### PR TITLE
[prerender] Log url of failed obj.

### DIFF
--- a/src/prerenderContent/prerenderObjs.js
+++ b/src/prerenderContent/prerenderObjs.js
@@ -23,8 +23,10 @@ export default async function prerenderObjs(
         await Promise.all(prerenderedFiles.map(storeResult));
       } catch (e) {
         failedCount += 1;
+        const pageId = obj.id();
+        const pageUrl = Scrivito.urlFor(obj);
         reportError(
-          `Error while processing obj ${obj.id()}. Skipping file.`,
+          `Error while processing obj ${pageId} (${pageUrl}). Skipping file.`,
           e.message,
           e
         );


### PR DESCRIPTION
Wished by Andreas.

FYI: `Scrivito.urlFor` is called outside of a `load` context. But at the time of the call `Scrivito.urlFor` should have already all needed data to not complain about incomplete data.