### PR TITLE
Extract comments from bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,6 +109,7 @@ function webpackConfig(env = {}) {
       minimizer: [
         new TerserPlugin({
           cache: true,
+          extractComments: true,
           parallel: true,
           terserOptions: { ecma: 5 },
         }),


### PR DESCRIPTION
Saves 2.15 k

See https://github.com/webpack-contrib/terser-webpack-plugin#extractcomments

IMO the licence is still distributed with the software, but if you are unsure about legal implications, feel free to close.