### PR TITLE
css: Use font-display: swap

### DIFF
--- a/src/assets/stylesheets/_pt_sans_narrow.scss
+++ b/src/assets/stylesheets/_pt_sans_narrow.scss
@@ -3,6 +3,7 @@
   font-family: "PT Sans Narrow";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local("PT Sans Narrow"), local("PTSans-Narrow"),
     url(../fonts/pt-sans-narrow/pt-sans-narrow-v8-latin-ext-regular.woff2)
       format("woff2"),
@@ -16,6 +17,7 @@
   font-family: "PT Sans Narrow";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local("PT Sans Narrow"), local("PTSans-Narrow"),
     url(../fonts/pt-sans-narrow/pt-sans-narrow-v8-latin-regular.woff2)
       format("woff2"),
@@ -30,6 +32,7 @@
   font-family: "PT Sans Narrow";
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: local("PT Sans Narrow Bold"), local("PTSans-NarrowBold"),
     url(../fonts/pt-sans-narrow/pt-sans-narrow-v8-latin-ext-700.woff2)
       format("woff2"),
@@ -43,6 +46,7 @@
   font-family: "PT Sans Narrow";
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: local("PT Sans Narrow Bold"), local("PTSans-NarrowBold"),
     url(../fonts/pt-sans-narrow/pt-sans-narrow-v8-latin-700.woff2)
       format("woff2"),

--- a/src/assets/stylesheets/_source_sans_pro.scss
+++ b/src/assets/stylesheets/_source_sans_pro.scss
@@ -3,6 +3,7 @@
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: local("Source Sans Pro Light"), local("SourceSansPro-Light"),
     url("../fonts/source-sans-pro/source-sans-pro-v11-latin-300.woff2")
       format("woff2"),
@@ -18,6 +19,7 @@
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local("Source Sans Pro Regular"), local("SourceSansPro-Regular"),
     url("../fonts/source-sans-pro/source-sans-pro-v11-latin-regular.woff2")
       format("woff2"),
@@ -33,6 +35,7 @@
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src: local("Source Sans Pro SemiBold"), local("SourceSansPro-SemiBold"),
     url("../fonts/source-sans-pro/source-sans-pro-v11-latin-600.woff2")
       format("woff2"),
@@ -48,6 +51,7 @@
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: local("Source Sans Pro Bold"), local("SourceSansPro-Bold"),
     url("../fonts/source-sans-pro/source-sans-pro-v11-latin-700.woff2")
       format("woff2"),
@@ -63,6 +67,7 @@
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: local("Source Sans Pro Light"), local("SourceSansPro-Light"),
     url("../fonts/source-sans-pro/source-sans-pro-v11-latin-ext-300.woff2")
       format("woff2"),
@@ -77,6 +82,7 @@
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local("Source Sans Pro Regular"), local("SourceSansPro-Regular"),
     url("../fonts/source-sans-pro/source-sans-pro-v11-latin-ext-regular.woff2")
       format("woff2"),
@@ -91,6 +97,7 @@
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src: local("Source Sans Pro SemiBold"), local("SourceSansPro-SemiBold"),
     url("../fonts/source-sans-pro/source-sans-pro-v11-latin-ext-600.woff2")
       format("woff2"),
@@ -105,6 +112,7 @@
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: local("Source Sans Pro Bold"), local("SourceSansPro-Bold"),
     url("../fonts/source-sans-pro/source-sans-pro-v11-latin-ext-700.woff2")
       format("woff2"),

--- a/src/assets/stylesheets/fontawesome/_path.scss
+++ b/src/assets/stylesheets/fontawesome/_path.scss
@@ -17,4 +17,5 @@
   //  src: url('#{$fa-font-path}/FontAwesome.otf') format('opentype'); // used when developing fonts
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -109,7 +109,7 @@ html {
 }
 
 body {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: "Source Sans Pro", $font-family-sans-serif;
   font-weight: normal;
   font-size: 16px;
   line-height: 1.5em;
@@ -168,7 +168,7 @@ h6,
 .h4,
 .h5,
 .h6 {
-  font-family: "PT Sans Narrow", sans-serif;
+  font-family: "PT Sans Narrow", $font-family-sans-serif;
   font-weight: 400;
   color: $theme-greydark;
   margin: 0 0 15px 0;
@@ -193,7 +193,7 @@ h3,
 }
 h4,
 .h4 {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: "Source Sans Pro", $font-family-sans-serif;
   font-weight: 300;
   font-size: 22px;
   line-height: 30px;
@@ -201,7 +201,7 @@ h4,
 }
 h5,
 .h5 {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: "Source Sans Pro", $font-family-sans-serif;
   font-size: 16px;
 }
 h6,
@@ -324,7 +324,7 @@ small,
 }
 
 .hero-bold {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: "Source Sans Pro", $font-family-sans-serif;
   font-weight: 700;
   font-size: 180px;
   text-transform: uppercase;
@@ -336,7 +336,7 @@ small,
   color: $secondary !important;
 }
 .hero-small {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: "Source Sans Pro", $font-family-sans-serif;
   font-weight: 300;
   font-size: 30px;
   line-height: 1;
@@ -1414,7 +1414,7 @@ section.navbar-fixed {
   color: $secondary;
   font-size: 80px;
   line-height: 80px;
-  font-family: "PT Sans Narrow", sans-serif;
+  font-family: "PT Sans Narrow", $font-family-sans-serif;
   font-weight: 700;
 }
 .fact .key {
@@ -1651,7 +1651,7 @@ section.navbar-fixed {
   line-height: 62px;
   border: 10px solid #fff;
   display: block;
-  font-family: "PT Sans Narrow", sans-serif;
+  font-family: "PT Sans Narrow", $font-family-sans-serif;
   font-weight: 700;
   text-align: center;
   position: absolute;
@@ -1798,7 +1798,7 @@ section.navbar-fixed {
   line-height: 62px;
   border: 10px solid #fff;
   display: block;
-  font-family: "PT Sans Narrow", sans-serif;
+  font-family: "PT Sans Narrow", $font-family-sans-serif;
   font-weight: 700;
   text-align: center;
   background: $secondary;
@@ -1938,7 +1938,7 @@ _:-ms-fullscreen,
   border-radius: 50%;
   line-height: 60px;
   text-align: center;
-  font-family: "PT Sans Narrow", sans-serif;
+  font-family: "PT Sans Narrow", $font-family-sans-serif;
   font-weight: 600;
 }
 .box-card .box-image {
@@ -3122,7 +3122,7 @@ img.cookie-img {
 .tick-list li {
   position: relative;
   padding: 0 0 20px 17px;
-  font-family: "PT Sans Narrow", sans-serif;
+  font-family: "PT Sans Narrow", $font-family-sans-serif;
   font-weight: 400;
   font-size: 20px;
 }

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1414,7 +1414,7 @@ section.navbar-fixed {
   color: $secondary;
   font-size: 80px;
   line-height: 80px;
-  font-family: "PT Sans Narrow";
+  font-family: "PT Sans Narrow", sans-serif;
   font-weight: 700;
 }
 .fact .key {

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -43,6 +43,19 @@ $screen-lg-min: 1200px;
 $slick-loader-path: "~slick-carousel/slick/";
 $slick-font-path: "~slick-carousel/slick/fonts/";
 
+@font-face {
+  font-family: "slick_swap";
+  font-display: swap;
+  src: url($slick-font-path+"slick.eot");
+  src: url($slick-font-path+"slick.eot?#iefix") format("embedded-opentype"),
+    url($slick-font-path+"slick.woff") format("woff"),
+    url($slick-font-path+"slick.ttf") format("truetype"),
+    url($slick-font-path+"slick.svg#slick") format("svg");
+  font-weight: normal;
+  font-style: normal;
+}
+$slick-font-family: "slick_swap";
+
 @import "~slick-carousel/slick/slick.scss";
 @import "~slick-carousel/slick/slick-theme.scss";
 


### PR DESCRIPTION
While downloading a custom font (e.g. PT Sans Narrow or Source Sans Pro) another system font should be shown.

This improves the "First Meaningful Paint" metric in lighthouse:

### Previously
<img width="363" alt="previous first meaningful paint" src="https://user-images.githubusercontent.com/86275/51310928-07a91600-1a48-11e9-98ad-32b9cb6ae0e9.png">

### Now
<img width="367" alt="new first meaningful paint" src="https://user-images.githubusercontent.com/86275/51310926-07a91600-1a48-11e9-9b15-a3c007b5a91f.png">

See https://css-tricks.com/font-display-masses/ for details on the css flag. Currently Firefox, Chrome and Safari (Mobile) have implemented this feature. Only IE does not support the feature, but will not break if used.