### PR TITLE
Bugfix: Filter tags in ThumbnailGalleryWidget correctly.

### DIFF
--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -129,7 +129,7 @@ const Thumbnail = Scrivito.connect(({ widget, openLightbox, currentTag }) => {
     "gallery-box",
     "gutter0",
   ];
-  if (currentTag && tags.includes(currentTag)) {
+  if (currentTag && !tags.includes(currentTag)) {
     classNames.push("squeezed");
   }
 


### PR DESCRIPTION
Fixes #173.

Thanks to @capriosa for the report and the bugfix!