### PR TITLE
Reduce bundle size by setting webpack node to false

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5828,6 +5828,11 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsontoxml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-1.0.1.tgz",
+      "integrity": "sha512-dtKGq0K8EWQBRqcAaePSgKR4Hyjfsz/LkurHSV3Cxk4H+h2fWDeaN2jzABz+ZmOJylgXS7FGeWmbZ6jgYUMdJQ=="
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -10470,11 +10475,6 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
-    },
-    "xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xregexp": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "generator-scrivito": "file:generator-scrivito",
     "is-empty": "^1.2.0",
     "jquery": "^3.3.1",
+    "jsontoxml": "^1.0.1",
     "lodash-es": "^4.17.11",
     "mini-css-extract-plugin": "^0.5.0",
     "moment-from-now": "0.0.4",
@@ -68,7 +69,6 @@
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.2.1",
     "webpackbar": "^3.1.5",
-    "xml": "^1.0.1",
     "zip-webpack-plugin": "^3.0.0"
   },
   "scripts": {

--- a/src/prerenderContent/prerenderSitemap.js
+++ b/src/prerenderContent/prerenderSitemap.js
@@ -1,6 +1,6 @@
 /* eslint no-console: "off" */
 import * as Scrivito from "scrivito";
-import xml from "xml";
+import xml from "jsontoxml";
 import formatDate from "../utils/formatDate";
 
 export default async function prerenderSitemap(
@@ -25,13 +25,14 @@ function sitemapXml(objClassesWhitelist) {
   const sitemapUrls = pages.map(pageToSitemapUrl);
 
   const content = xml(
-    {
-      urlset: [
-        { _attr: { xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9" } },
-        ...sitemapUrls,
-      ],
-    },
-    { declaration: true }
+    [
+      {
+        name: "urlset",
+        attrs: { xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9" },
+        children: sitemapUrls,
+      },
+    ],
+    { xmlHeader: true }
   );
 
   const itemsCount = sitemapUrls.length;
@@ -40,9 +41,9 @@ function sitemapXml(objClassesWhitelist) {
 
 function pageToSitemapUrl(page) {
   return {
-    url: [
-      { loc: Scrivito.urlFor(page) },
-      { lastmod: formatDate(page.lastChanged(), "yyyy-mm-dd") },
-    ],
+    url: {
+      loc: Scrivito.urlFor(page),
+      lastmod: formatDate(page.lastChanged(), "yyyy-mm-dd"),
+    },
   };
 }

--- a/src/prerenderContent/prerenderSitemap.js
+++ b/src/prerenderContent/prerenderSitemap.js
@@ -1,6 +1,6 @@
 /* eslint no-console: "off" */
 import * as Scrivito from "scrivito";
-import xml from "jsontoxml";
+import jsontoxml from "jsontoxml";
 import formatDate from "../utils/formatDate";
 
 export default async function prerenderSitemap(

--- a/src/prerenderContent/prerenderSitemap.js
+++ b/src/prerenderContent/prerenderSitemap.js
@@ -24,7 +24,7 @@ function sitemapXml(objClassesWhitelist) {
     .take();
   const sitemapUrls = pages.map(pageToSitemapUrl);
 
-  const content = xml(
+  const content = jsontoxml(
     [
       {
         name: "urlset",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,7 @@ function webpackConfig(env = {}) {
 
   return {
     mode: isProduction ? "production" : "development",
+    node: false,
     context: path.join(__dirname, "src"),
     entry: generateEntry({ isPrerendering }),
     module: {


### PR DESCRIPTION
I just discovered unexpected polyfill code in my bundle. That's how I found out about this option.
Luckily the Example App had only one dependency on a node feature: `stream` used by `sax` used by `xml`.

### Before/After

![image](https://user-images.githubusercontent.com/986170/54357544-9ad48580-465e-11e9-8975-6ebae9bd58da.png)
