### PR TITLE
Simpler eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,6 @@
     ],
     "no-use-before-define": [2, { "functions": false, "variables": false }],
     "prettier/prettier": "error",
-    "prefer-destructuring": 0,
     "react/display-name": 0,
     "react/jsx-no-undef": ["error", { "allowGlobals": true }],
     "react/prop-types": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,9 +3,7 @@
   "plugins": ["import", "prettier", "react"],
   "settings": {
     "import/resolver": "webpack",
-    "react": {
-      "version": "16"
-    }
+    "react": { "version": "16" }
   },
   "parserOptions": {
     "ecmaVersion": 9,
@@ -43,21 +41,15 @@
   "overrides": [
     {
       "files": ["src/utils/textExtract.js", "src/utils/textExtractRegistry.js"],
-      "rules": {
-        "no-console": 0
-      }
+      "rules": { "no-console": 0 }
     },
     {
       "files": ["src/index.js"],
-      "rules": {
-        "import/first": 0
-      }
+      "rules": { "import/first": 0 }
     },
     {
       "files": ["src/Components/NotFoundErrorPage.js"],
-      "rules": {
-        "class-methods-use-this": 0
-      }
+      "rules": { "class-methods-use-this": 0 }
     },
     {
       "files": ["src/Components/GoogleAnalytics.js"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,7 @@
       2,
       { "args": "all", "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
     ],
-    "no-use-before-define": 0,
+    "no-use-before-define": [2, { "functions": false, "variables": false }],
     "object-curly-newline": 0,
     "prettier/prettier": "error",
     "prefer-destructuring": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,6 @@
   },
   "rules": {
     "curly": ["error", "all"],
-    "default-case": 0,
     "function-paren-newline": 0,
     "import/no-amd": 1,
     "import/no-commonjs": 1,

--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,6 @@
   },
   "rules": {
     "curly": ["error", "all"],
-    "function-paren-newline": 0,
     "import/no-amd": 1,
     "import/no-commonjs": 1,
     "import/no-extraneous-dependencies": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,6 @@
     "btoa": true
   },
   "rules": {
-    "arrow-body-style": 0,
     "consistent-return": 0,
     "curly": ["error", "all"],
     "default-case": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,8 +12,8 @@
     "sourceType": "module"
   },
   "extends": [
-    "eslint:recommended",
     "airbnb/base",
+    "eslint:recommended",
     "plugin:react/recommended",
     "prettier"
   ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,6 @@
       { "args": "all", "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
     ],
     "no-use-before-define": [2, { "functions": false, "variables": false }],
-    "object-curly-newline": 0,
     "prettier/prettier": "error",
     "prefer-destructuring": 0,
     "react/display-name": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,6 @@
     "import/no-nodejs-modules": 1,
     "no-debugger": 1,
     "no-param-reassign": [2, { "props": false }],
-    "no-shadow": [2, { "allow": ["error", "result"] }],
     "no-throw-literal": 0,
     "no-unused-vars": [
       2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,6 @@
     "curly": ["error", "all"],
     "import/no-amd": 1,
     "import/no-commonjs": 1,
-    "import/no-extraneous-dependencies": "off",
     "import/no-nodejs-modules": 1,
     "no-debugger": 1,
     "no-param-reassign": [2, { "props": false }],

--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,7 @@
     "no-use-before-define": [2, { "functions": false, "variables": false }],
     "prettier/prettier": 1,
     "react/display-name": 0,
-    "react/jsx-no-undef": ["error", { "allowGlobals": true }],
+    "react/jsx-no-undef": [2, { "allowGlobals": true }],
     "react/prop-types": 0,
     "vars-on-top": 0
   },

--- a/.eslintrc
+++ b/.eslintrc
@@ -28,9 +28,9 @@
     "import/no-commonjs": 2,
     "import/no-nodejs-modules": 2,
     "no-debugger": 1,
-    "no-param-reassign": [2, { "props": false }],
+    "no-param-reassign": [1, { "props": false }],
     "no-unused-vars": [
-      2,
+      1,
       { "args": "all", "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
     ],
     "no-use-before-define": [2, { "functions": false, "variables": false }],

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,6 @@
     "import/no-nodejs-modules": 1,
     "no-debugger": 1,
     "no-param-reassign": [2, { "props": false }],
-    "no-throw-literal": 0,
     "no-unused-vars": [
       2,
       { "args": "all", "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }

--- a/.eslintrc
+++ b/.eslintrc
@@ -24,9 +24,9 @@
   },
   "rules": {
     "curly": [1, "all"],
-    "import/no-amd": 1,
-    "import/no-commonjs": 1,
-    "import/no-nodejs-modules": 1,
+    "import/no-amd": 2,
+    "import/no-commonjs": 2,
+    "import/no-nodejs-modules": 2,
     "no-debugger": 1,
     "no-param-reassign": [2, { "props": false }],
     "no-unused-vars": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,7 @@
     "btoa": true
   },
   "rules": {
-    "curly": ["error", "all"],
+    "curly": [1, "all"],
     "import/no-amd": 1,
     "import/no-commonjs": 1,
     "import/no-nodejs-modules": 1,
@@ -34,7 +34,7 @@
       { "args": "all", "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
     ],
     "no-use-before-define": [2, { "functions": false, "variables": false }],
-    "prettier/prettier": "error",
+    "prettier/prettier": 1,
     "react/display-name": 0,
     "react/jsx-no-undef": ["error", { "allowGlobals": true }],
     "react/prop-types": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,6 @@
     "btoa": true
   },
   "rules": {
-    "consistent-return": 0,
     "curly": ["error", "all"],
     "default-case": 0,
     "function-paren-newline": 0,

--- a/src/Components/GoogleAnalytics.js
+++ b/src/Components/GoogleAnalytics.js
@@ -13,7 +13,7 @@ class GoogleAnalytics extends React.Component {
     Scrivito.load(() => {
       const rootPage = Scrivito.Obj.root();
       if (!rootPage) {
-        return;
+        return undefined;
       }
       return rootPage.get("googleAnalyticsTrackingId");
     }).then(trackingId => {

--- a/src/Components/Intercom.js
+++ b/src/Components/Intercom.js
@@ -13,7 +13,7 @@ class Intercom extends React.Component {
     Scrivito.load(() => {
       const rootPage = Scrivito.Obj.root();
       if (!rootPage) {
-        return;
+        return undefined;
       }
       return rootPage.get("intercomAppId");
     }).then(intercomAppId => {

--- a/src/Components/Navigation/Logo.js
+++ b/src/Components/Navigation/Logo.js
@@ -15,6 +15,8 @@ function logoObj({ scrolled, navigationStyle }) {
   if (root) {
     return root.get(logoVersion);
   }
+
+  return undefined;
 }
 
 function Logo({ scrolled, navigationStyle }) {

--- a/src/Components/Navigation/currentPageNavigationOptions.js
+++ b/src/Components/Navigation/currentPageNavigationOptions.js
@@ -20,6 +20,8 @@ function currentPageNavigationOptions() {
         return pageNavigationOptions(Scrivito.currentPage());
       case "SearchResults":
         return searchResultsNavigationOptions(Scrivito.currentPage());
+      default:
+        break;
     }
   }
 

--- a/src/Components/SchemaDotOrg.js
+++ b/src/Components/SchemaDotOrg.js
@@ -29,6 +29,8 @@ function dataFromItem(item) {
       return dataFromEvent(item);
     case "Job":
       return dataFromJob(item);
+    default:
+      break;
   }
 
   throw `SchemaDotOrg for objClass ${item.objClass()} not supported!`;

--- a/src/Components/SchemaDotOrg.js
+++ b/src/Components/SchemaDotOrg.js
@@ -30,10 +30,10 @@ function dataFromItem(item) {
     case "Job":
       return dataFromJob(item);
     default:
-      break;
+      throw new Error(
+        `SchemaDotOrg for objClass ${item.objClass()} not supported!`
+      );
   }
-
-  throw `SchemaDotOrg for objClass ${item.objClass()} not supported!`;
 }
 
 function pruneEmptyValues(data) {

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -293,11 +293,12 @@ class GridLayoutEditor extends React.Component {
     }
 
     if (wantedCols === 5) {
-      return this.props.adjustGrid([2, 2, 2, 2, 4]);
+      this.props.adjustGrid([2, 2, 2, 2, 4]);
+      return;
     }
 
     const newColSize = 12 / wantedCols;
-    return this.props.adjustGrid(times(wantedCols).map(() => newColSize));
+    this.props.adjustGrid(times(wantedCols).map(() => newColSize));
   }
 
   render() {

--- a/src/Components/ScrivitoExtensions/IconEditorTab.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab.js
@@ -34,7 +34,7 @@ class IconEditorTab extends React.Component {
   }
 
   render() {
-    const widget = this.props.widget;
+    const { widget } = this.props;
     const currentIcon = widget.get("icon");
 
     return (

--- a/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
+++ b/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
@@ -3,7 +3,7 @@ import * as Scrivito from "scrivito";
 import BlogPostPreviewList from "../../Components/BlogPost/BlogPostPreviewList";
 
 Scrivito.provideComponent("BlogOverviewWidget", ({ widget }) => {
-  let tag = Scrivito.currentPageParams().tag;
+  let { tag } = Scrivito.currentPageParams();
 
   const tags = widget.get("tags");
   if (!tag && tags.length) {

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -63,7 +63,7 @@ class ThumbnailGalleryComponent extends React.Component {
   }
 
   render() {
-    const widget = this.props.widget;
+    const { widget } = this.props;
     const images = widget
       .get("images")
       .filter(subWidget => isImage(subWidget.get("image")));

--- a/src/prerenderContent/filenameFromUrl.js
+++ b/src/prerenderContent/filenameFromUrl.js
@@ -1,5 +1,5 @@
 export default function filenameFromUrl(url) {
-  const pathname = new URL(url).pathname;
+  const { pathname } = new URL(url);
   if (pathname === "/") {
     return "/index.html";
   }

--- a/src/utils/textExtract.js
+++ b/src/utils/textExtract.js
@@ -60,9 +60,9 @@ function assertValidValue(value, type) {
       return isString(value);
     case "widgetlist":
       return Array.isArray(value);
+    default:
+      return true;
   }
-
-  return true;
 }
 
 function textExtractFromMetadata(objOrWidget, attribute) {


### PR DESCRIPTION
Removed a lot of overwrites of eslint rules.

The only default rules, that are still off are `react/display-name`, `react/prop-types` and `vars-on-top`.