### PR TITLE
index.css via css-loader

### DIFF
--- a/src/Widgets/TickListWidget/TickListWidgetClass.js
+++ b/src/Widgets/TickListWidget/TickListWidgetClass.js
@@ -1,5 +1,6 @@
 import * as Scrivito from "scrivito";
 import { registerTextExtract } from "../../utils/textExtractRegistry";
+import "./TickListWidgetStyles.scss";
 
 const TickListWidget = Scrivito.provideWidgetClass("TickListWidget", {
   attributes: {

--- a/src/Widgets/TickListWidget/TickListWidgetComponent.js
+++ b/src/Widgets/TickListWidget/TickListWidgetComponent.js
@@ -4,7 +4,7 @@ import * as Scrivito from "scrivito";
 Scrivito.provideComponent("TickListWidget", ({ widget }) => (
   <Scrivito.ContentTag
     tag="ul"
-    className="tick-list"
+    className="TickListWidget__list"
     content={widget}
     attribute="items"
   />

--- a/src/Widgets/TickListWidget/TickListWidgetComponent.js
+++ b/src/Widgets/TickListWidget/TickListWidgetComponent.js
@@ -4,7 +4,7 @@ import * as Scrivito from "scrivito";
 Scrivito.provideComponent("TickListWidget", ({ widget }) => (
   <Scrivito.ContentTag
     tag="ul"
-    className="TickListWidget__list"
+    className="tick-list-widget"
     content={widget}
     attribute="items"
   />

--- a/src/Widgets/TickListWidget/TickListWidgetStyles.scss
+++ b/src/Widgets/TickListWidget/TickListWidgetStyles.scss
@@ -3,19 +3,19 @@
 @import "../../assets/stylesheets/fontawesome/core";
 @import "../../assets/stylesheets/colors";
 
-.TickListWidget__list {
+.tick-list-widget {
   list-style-type: none;
   padding-left: 15px;
   @include clearfix;
 }
-.TickListWidget__list li {
+.tick-list-widget li {
   position: relative;
   padding: 0 0 20px 17px;
   font-family: "PT Sans Narrow", sans-serif;
   font-weight: 400;
   font-size: 20px;
 }
-.TickListWidget__list li:before {
+.tick-list-widget li:before {
   display: block;
   position: absolute;
   top: 2px;

--- a/src/Widgets/TickListWidget/TickListWidgetStyles.scss
+++ b/src/Widgets/TickListWidget/TickListWidgetStyles.scss
@@ -3,19 +3,19 @@
 @import "../../assets/stylesheets/fontawesome/core";
 @import "../../assets/stylesheets/colors";
 
-.tick-list {
+.TickListWidget__list {
   list-style-type: none;
   padding-left: 15px;
   @include clearfix;
 }
-.tick-list li {
+.TickListWidget__list li {
   position: relative;
   padding: 0 0 20px 17px;
   font-family: "PT Sans Narrow", sans-serif;
   font-weight: 400;
   font-size: 20px;
 }
-.tick-list li:before {
+.TickListWidget__list li:before {
   display: block;
   position: absolute;
   top: 2px;

--- a/src/Widgets/TickListWidget/TickListWidgetStyles.scss
+++ b/src/Widgets/TickListWidget/TickListWidgetStyles.scss
@@ -1,3 +1,8 @@
+@import "../../assets/stylesheets/bootstrap/mixins/clearfix";
+@import "../../assets/stylesheets/fontawesome/variables";
+@import "../../assets/stylesheets/fontawesome/core";
+@import "../../assets/stylesheets/colors";
+
 .tick-list {
   list-style-type: none;
   padding-left: 15px;
@@ -16,5 +21,6 @@
   top: 2px;
   left: -15px;
   content: "\f00c" !important;
+  color: $secondary;
   @extend .fa;
 }

--- a/src/Widgets/TickListWidget/TickListWidgetStyles.scss
+++ b/src/Widgets/TickListWidget/TickListWidgetStyles.scss
@@ -1,0 +1,20 @@
+.tick-list {
+  list-style-type: none;
+  padding-left: 15px;
+  @include clearfix;
+}
+.tick-list li {
+  position: relative;
+  padding: 0 0 20px 17px;
+  font-family: "PT Sans Narrow", sans-serif;
+  font-weight: 400;
+  font-size: 20px;
+}
+.tick-list li:before {
+  display: block;
+  position: absolute;
+  top: 2px;
+  left: -15px;
+  content: "\f00c" !important;
+  @extend .fa;
+}

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
@@ -24,7 +24,7 @@ Scrivito.provideComponent("VimeoVideoWidget", ({ widget }) => {
     >
       <iframe
         src={`https://player.vimeo.com/video/${vimeoVideoId}`}
-        className="VimeoVideoWidget__fullsize-iframe"
+        className="vimeo-video-widget--fullsize-iframe"
         frameBorder="0"
         allowFullScreen
         webkitallowfullscreen="true"

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import "./VimeoVideoWidgetStyles.scss";
 
 Scrivito.provideComponent("VimeoVideoWidget", ({ widget }) => {
   const vimeoVideoId = widget.get("vimeoVideoId");
@@ -23,7 +24,7 @@ Scrivito.provideComponent("VimeoVideoWidget", ({ widget }) => {
     >
       <iframe
         src={`https://player.vimeo.com/video/${vimeoVideoId}`}
-        className="fullsize-iframe"
+        className="vimeo-fullsize-iframe"
         frameBorder="0"
         allowFullScreen
         webkitallowfullscreen="true"

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
@@ -24,7 +24,7 @@ Scrivito.provideComponent("VimeoVideoWidget", ({ widget }) => {
     >
       <iframe
         src={`https://player.vimeo.com/video/${vimeoVideoId}`}
-        className="vimeo-fullsize-iframe"
+        className="VimeoVideoWidget__fullsize-iframe"
         frameBorder="0"
         allowFullScreen
         webkitallowfullscreen="true"

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetStyles.scss
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetStyles.scss
@@ -1,4 +1,4 @@
-.VimeoVideoWidget__fullsize-iframe {
+.vimeo-video-widget--fullsize-iframe {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetStyles.scss
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetStyles.scss
@@ -1,0 +1,7 @@
+.vimeo-fullsize-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetStyles.scss
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetStyles.scss
@@ -1,4 +1,4 @@
-.vimeo-fullsize-iframe {
+.VimeoVideoWidget__fullsize-iframe {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
@@ -24,7 +24,7 @@ Scrivito.provideComponent("YoutubeVideoWidget", ({ widget }) => {
     >
       <iframe
         src={`https://www.youtube.com/embed/${youtubeVideoId}`}
-        className="YoutubeVideoWidget__fullsize-iframe"
+        className="youtube-video-widget--fullsize-iframe"
         frameBorder="0"
         allow="autoplay; encrypted-media"
         allowFullScreen

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
@@ -24,7 +24,7 @@ Scrivito.provideComponent("YoutubeVideoWidget", ({ widget }) => {
     >
       <iframe
         src={`https://www.youtube.com/embed/${youtubeVideoId}`}
-        className="youtube-fullsize-iframe"
+        className="YoutubeVideoWidget__fullsize-iframe"
         frameBorder="0"
         allow="autoplay; encrypted-media"
         allowFullScreen

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import "./YoutubeVideoWidgetStyles.scss";
 
 Scrivito.provideComponent("YoutubeVideoWidget", ({ widget }) => {
   const youtubeVideoId = widget.get("youtubeVideoId");
@@ -23,7 +24,7 @@ Scrivito.provideComponent("YoutubeVideoWidget", ({ widget }) => {
     >
       <iframe
         src={`https://www.youtube.com/embed/${youtubeVideoId}`}
-        className="fullsize-iframe"
+        className="youtube-fullsize-iframe"
         frameBorder="0"
         allow="autoplay; encrypted-media"
         allowFullScreen

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetStyles.scss
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetStyles.scss
@@ -1,4 +1,4 @@
-.YoutubeVideoWidget__fullsize-iframe {
+.youtube-video-widget--fullsize-iframe {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetStyles.scss
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetStyles.scss
@@ -1,4 +1,4 @@
-.youtube-fullsize-iframe {
+.YoutubeVideoWidget__fullsize-iframe {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetStyles.scss
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetStyles.scss
@@ -1,0 +1,7 @@
+.youtube-fullsize-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -3134,10 +3134,8 @@ img.cookie-img {
   position: absolute;
   top: 2px;
   left: -15px;
-  @extend .fa;
-}
-.tick-list li:before {
   content: "\f00c" !important;
+  @extend .fa;
 }
 
 /* Text image widget ************ TBD ************

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -122,7 +122,7 @@ html {
 }
 
 body {
-  font-family: "Source Sans Pro", $font-family-sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: normal;
   font-size: 16px;
   line-height: 1.5em;
@@ -181,7 +181,7 @@ h6,
 .h4,
 .h5,
 .h6 {
-  font-family: "PT Sans Narrow", $font-family-sans-serif;
+  font-family: "PT Sans Narrow", sans-serif;
   font-weight: 400;
   color: $theme-greydark;
   margin: 0 0 15px 0;
@@ -206,7 +206,7 @@ h3,
 }
 h4,
 .h4 {
-  font-family: "Source Sans Pro", $font-family-sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 300;
   font-size: 22px;
   line-height: 30px;
@@ -214,7 +214,7 @@ h4,
 }
 h5,
 .h5 {
-  font-family: "Source Sans Pro", $font-family-sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-size: 16px;
 }
 h6,
@@ -337,7 +337,7 @@ small,
 }
 
 .hero-bold {
-  font-family: "Source Sans Pro", $font-family-sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 700;
   font-size: 180px;
   text-transform: uppercase;
@@ -349,7 +349,7 @@ small,
   color: $secondary !important;
 }
 .hero-small {
-  font-family: "Source Sans Pro", $font-family-sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 300;
   font-size: 30px;
   line-height: 1;
@@ -1427,7 +1427,7 @@ section.navbar-fixed {
   color: $secondary;
   font-size: 80px;
   line-height: 80px;
-  font-family: "PT Sans Narrow", $font-family-sans-serif;
+  font-family: "PT Sans Narrow", sans-serif;
   font-weight: 700;
 }
 .fact .key {
@@ -1664,7 +1664,7 @@ section.navbar-fixed {
   line-height: 62px;
   border: 10px solid #fff;
   display: block;
-  font-family: "PT Sans Narrow", $font-family-sans-serif;
+  font-family: "PT Sans Narrow", sans-serif;
   font-weight: 700;
   text-align: center;
   position: absolute;
@@ -1811,7 +1811,7 @@ section.navbar-fixed {
   line-height: 62px;
   border: 10px solid #fff;
   display: block;
-  font-family: "PT Sans Narrow", $font-family-sans-serif;
+  font-family: "PT Sans Narrow", sans-serif;
   font-weight: 700;
   text-align: center;
   background: $secondary;
@@ -1951,7 +1951,7 @@ _:-ms-fullscreen,
   border-radius: 50%;
   line-height: 60px;
   text-align: center;
-  font-family: "PT Sans Narrow", $font-family-sans-serif;
+  font-family: "PT Sans Narrow", sans-serif;
   font-weight: 600;
 }
 .box-card .box-image {
@@ -3125,7 +3125,7 @@ img.cookie-img {
 .tick-list li {
   position: relative;
   padding: 0 0 20px 17px;
-  font-family: "PT Sans Narrow", $font-family-sans-serif;
+  font-family: "PT Sans Narrow", sans-serif;
   font-weight: 400;
   font-size: 20px;
 }

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -2886,16 +2886,6 @@ img.cookie-img {
   }
 }
 
-/* content iframes properties
-=================================================================== */
-.fullsize-iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
 /* section google map
 =================================================================== */
 

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -3114,30 +3114,6 @@ img.cookie-img {
   }
 }
 
-/* list *
-=================================================================== */
-
-.tick-list {
-  list-style-type: none;
-  padding-left: 15px;
-  @include clearfix;
-}
-.tick-list li {
-  position: relative;
-  padding: 0 0 20px 17px;
-  font-family: "PT Sans Narrow", sans-serif;
-  font-weight: 400;
-  font-size: 20px;
-}
-.tick-list li:before {
-  display: block;
-  position: absolute;
-  top: 2px;
-  left: -15px;
-  content: "\f00c" !important;
-  @extend .fa;
-}
-
 /* Text image widget ************ TBD ************
 =================================================================== */
 .text_image_widget {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import "./assets/stylesheets/index.scss";
 import "./polyfills";
 import * as React from "react";
 import * as ReactDOM from "react-dom";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,9 +86,7 @@ function webpackConfig(env = {}) {
         {
           test: /\.s?css$/,
           use: [
-            {
-              loader: MiniCssExtractPlugin.loader,
-            },
+            { loader: MiniCssExtractPlugin.loader },
             "css-loader",
             "sass-loader",
           ],
@@ -149,7 +147,6 @@ function generateEntry({ isPrerendering }) {
     index: "./index.js",
     google_analytics: "./google_analytics.js",
     scrivito_extensions: "./scrivito_extensions.js",
-    "index.css": "./assets/stylesheets/index.scss",
   };
   if (isPrerendering) {
     entry.prerender_content = "./prerender_content.js";
@@ -179,7 +176,7 @@ function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
     ]),
     new ExtendCspHeadersWebpackPlugin(),
     new MiniCssExtractPlugin({
-      filename: "[name]",
+      filename: "[name].css",
     }),
     new webpack.optimize.ModuleConcatenationPlugin(),
   ];


### PR DESCRIPTION
Motivation: This PR sets the base-line to further improve our stylesheets.

Ideally we want a style sheet file per widget/obj, with a base-line `index.scss`. `css-loader` and `MiniCssExtractPlugin` will combine this multiple css files into one big `index.css` file.

As a proof of concept I converted the styling of `TickListWidget`, `VimeoVideoWidget` and `YoutubeVideoWidget` to show, how it is done.