### PR TITLE
Disable webpack node stuff, IE/Edge compatible

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,7 @@ function webpackConfig(env = {}) {
 
   return {
     mode: isProduction ? "production" : "development",
+    node: false,
     context: path.join(__dirname, "src"),
     entry: generateEntry({ isPrerendering }),
     module: {
@@ -194,7 +195,14 @@ function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
       })
     );
   } else {
-    plugins.push(new webpack.SourceMapDevToolPlugin({}));
+    plugins.push(
+      new webpack.SourceMapDevToolPlugin({}),
+      // make hot reloading work in IE/Edge: (see https://github.com/nfl/react-helmet/issues/336)
+      new webpack.DefinePlugin({
+        "window.requestAnimationFrame":
+          "window.requestAnimationFrame.bind(window)",
+      })
+    );
   }
 
   return plugins;


### PR DESCRIPTION
see #176 and 5c9f833b2aab661a7cd82b5df02a11c1dd02b212

Workaround for https://github.com/nfl/react-helmet/issues/336 in the spirit of https://github.com/vuejs/vue/issues/4465#issuecomment-266731666.

The issue is caused by a mix of IE/Edge and `eval` (Webpack hot reloading).
Thus, the responsibility doesn't really lie with Helmet, even though others (Vue) were so kind to implement a workaround.