### PR TITLE
The google bot is no longer limited to an old version of chrome.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,9 +66,7 @@ function webpackConfig(env = {}) {
                       shippedProposals: true,
                       useBuiltIns: "usage",
                       corejs: "2",
-                      targets: {
-                        browsers: ["Chrome >= 41", "last 2 versions"],
-                      },
+                      targets: { browsers: ["last 2 versions"] },
                     },
                   ],
                 ],


### PR DESCRIPTION
Therefore we no longer have to include polyfills for that old version.

See https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html for details.