### PR TITLE
Less warnings with prerendering and dev server

### DIFF
--- a/src/prerenderContent/generateHtml.js
+++ b/src/prerenderContent/generateHtml.js
@@ -21,9 +21,7 @@ export default function generateHtml({
     <script src="/js_snippets_head.js"></script>
   </head>
   <body ${bodyAttributes}>
-    <div id="application" data-scrivito-prerendering-obj-id="${objId}">
-      ${bodyContent}
-    </div>
+    <div id="application" data-scrivito-prerendering-obj-id="${objId}">${bodyContent}</div>
     <script src="${preloadDumpFileName}"></script>
     <script async src="/index.js"></script>
     <script src="/js_snippets_before_body_end.js"></script>


### PR DESCRIPTION
With the space, a local dev server serving the prerendered content would log this in the browser console:

```
Warning: Did not expect server HTML to contain the text node "
      " in <div>.
```