### PR TITLE
Redirect's openInUi considered harmful

### DIFF
--- a/src/Objs/Redirect/RedirectComponent.js
+++ b/src/Objs/Redirect/RedirectComponent.js
@@ -6,20 +6,16 @@ class RedirectComponent extends React.Component {
   componentDidMount() {
     Scrivito.load(() => {
       const link = this.props.page.get("link");
-      const openInUi = this.props.page.get("openInUi");
       const url = link && Scrivito.urlFor(link);
 
-      return { link, openInUi, url };
-    }).then(({ link, openInUi, url }) => {
+      return { link, url };
+    }).then(({ link, url }) => {
       if (!link) {
         return;
       }
 
       if (link.isExternal()) {
         window.top.location.replace(url);
-      } else if (openInUi === "yes") {
-        const scrivitoUiUrl = url.replace(/(\/\/[^/]+)/, "$1/scrivito");
-        window.top.location.replace(scrivitoUiUrl);
       } else {
         window.location.replace(url);
       }

--- a/src/Objs/Redirect/RedirectEditingConfig.js
+++ b/src/Objs/Redirect/RedirectEditingConfig.js
@@ -13,14 +13,6 @@ Scrivito.provideEditingConfig("Redirect", {
     link: {
       title: "Link",
     },
-    openInUi: {
-      title: "Open in Scrivito UI?",
-      description: "Default: No",
-      values: [{ value: "yes", title: "Yes" }, { value: "no", title: "No" }],
-    },
   },
-  properties: ["title", "link", "openInUi"],
-  initialContent: {
-    openInUi: "no",
-  },
+  properties: ["title", "link"],
 });

--- a/src/Objs/Redirect/RedirectObjClass.js
+++ b/src/Objs/Redirect/RedirectObjClass.js
@@ -4,7 +4,6 @@ const Redirect = Scrivito.provideObjClass("Redirect", {
   attributes: {
     title: "string",
     link: "link",
-    openInUi: ["enum", { values: ["yes", "no"] }],
   },
 });
 

--- a/src/Objs/RedirectToUi/RedirectToUiComponent.js
+++ b/src/Objs/RedirectToUi/RedirectToUiComponent.js
@@ -1,0 +1,37 @@
+import * as React from "react";
+import * as Scrivito from "scrivito";
+import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+
+class RedirectToUiComponent extends React.Component {
+  componentDidMount() {
+    Scrivito.load(() => {
+      const reference = this.props.page.get("reference");
+      const url = reference && Scrivito.urlFor(reference);
+
+      return url;
+    }).then(url => {
+      if (!url) {
+        return;
+      }
+
+      const scrivitoUiUrl = url.replace(/(\/\/[^/]+)/, "$1/scrivito");
+      window.top.location.replace(scrivitoUiUrl);
+    });
+  }
+
+  render() {
+    const reference = this.props.page.get("reference");
+
+    if (!reference) {
+      return (
+        <InPlaceEditingPlaceholder center>
+          Select a reference in the redirect to ui page properties.
+        </InPlaceEditingPlaceholder>
+      );
+    }
+
+    return null;
+  }
+}
+
+Scrivito.provideComponent("RedirectToUi", RedirectToUiComponent);

--- a/src/Objs/RedirectToUi/RedirectToUiComponent.js
+++ b/src/Objs/RedirectToUi/RedirectToUiComponent.js
@@ -1,35 +1,13 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
 
 class RedirectToUiComponent extends React.Component {
   componentDidMount() {
-    Scrivito.load(() => {
-      const reference = this.props.page.get("reference");
-      const url = reference && Scrivito.urlFor(reference);
-
-      return url;
-    }).then(url => {
-      if (!url) {
-        return;
-      }
-
-      const scrivitoUiUrl = url.replace(/(\/\/[^/]+)/, "$1/scrivito");
-      window.top.location.replace(scrivitoUiUrl);
-    });
+    const scrivitoUiUrl = window.location.origin + "/scrivito/";
+    window.top.location.replace(scrivitoUiUrl);
   }
 
   render() {
-    const reference = this.props.page.get("reference");
-
-    if (!reference) {
-      return (
-        <InPlaceEditingPlaceholder center>
-          Select a reference in the redirect to ui page properties.
-        </InPlaceEditingPlaceholder>
-      );
-    }
-
     return null;
   }
 }

--- a/src/Objs/RedirectToUi/RedirectToUiEditingConfig.js
+++ b/src/Objs/RedirectToUi/RedirectToUiEditingConfig.js
@@ -2,7 +2,7 @@ import * as Scrivito from "scrivito";
 import redirectObjIcon from "../../assets/images/redirect_obj.svg";
 
 Scrivito.provideEditingConfig("RedirectToUi", {
-  title: "Redirect To Ui",
+  title: "Redirect To UI",
   thumbnail: redirectObjIcon,
   hideInSelectionDialogs: true,
 });

--- a/src/Objs/RedirectToUi/RedirectToUiEditingConfig.js
+++ b/src/Objs/RedirectToUi/RedirectToUiEditingConfig.js
@@ -1,0 +1,18 @@
+import * as Scrivito from "scrivito";
+import redirectObjIcon from "../../assets/images/redirect_obj.svg";
+
+Scrivito.provideEditingConfig("RedirectToUi", {
+  title: "Redirect To Ui",
+  thumbnail: redirectObjIcon,
+  hideInSelectionDialogs: true,
+  attributes: {
+    title: {
+      title: "Title",
+      description: "Limit to 55 characters.",
+    },
+    reference: {
+      title: "Reference",
+    },
+  },
+  properties: ["title", "reference"],
+});

--- a/src/Objs/RedirectToUi/RedirectToUiEditingConfig.js
+++ b/src/Objs/RedirectToUi/RedirectToUiEditingConfig.js
@@ -5,14 +5,4 @@ Scrivito.provideEditingConfig("RedirectToUi", {
   title: "Redirect To Ui",
   thumbnail: redirectObjIcon,
   hideInSelectionDialogs: true,
-  attributes: {
-    title: {
-      title: "Title",
-      description: "Limit to 55 characters.",
-    },
-    reference: {
-      title: "Reference",
-    },
-  },
-  properties: ["title", "reference"],
 });

--- a/src/Objs/RedirectToUi/RedirectToUiObjClass.js
+++ b/src/Objs/RedirectToUi/RedirectToUiObjClass.js
@@ -1,10 +1,7 @@
 import * as Scrivito from "scrivito";
 
 const RedirectToUi = Scrivito.provideObjClass("RedirectToUi", {
-  attributes: {
-    title: "string",
-    reference: "reference",
-  },
+  attributes: {},
 });
 
 export default RedirectToUi;

--- a/src/Objs/RedirectToUi/RedirectToUiObjClass.js
+++ b/src/Objs/RedirectToUi/RedirectToUiObjClass.js
@@ -1,0 +1,10 @@
+import * as Scrivito from "scrivito";
+
+const RedirectToUi = Scrivito.provideObjClass("RedirectToUi", {
+  attributes: {
+    title: "string",
+    reference: "reference",
+  },
+});
+
+export default RedirectToUi;


### PR DESCRIPTION
Prior to this PR there has been only the `Redirect` obj, that surfed two different purposes: Redirect to a link or open a page in the Scrivito UI.

The second part is a very specific task, that we - more or less - only need on the example content on the first "call to action" button, where novice scrivito editors can try out scrivito. Outside of this narrow use-case no other editor would use it.

Other than that it does not add much value. On the contrary: It can even be harmful, if a regular redirect obj receives the "openInUi" tick. This can lead to a "harmless" redirect to break you page, since regular visitors are also redirected to the Scrivito UI.

This PR adds a dedicated `RedirectToUi` obj, that only has the purpose of redirecting to the UI. The regular `Redirect` obj no longer has the `openInUi` option, to decrease the risk of a redirect gone wrong.