### PR TITLE
Connect SearchIcon

### DIFF
--- a/src/Components/Navigation/Search.js
+++ b/src/Components/Navigation/Search.js
@@ -73,7 +73,7 @@ function oldestSearchResultsPage() {
     .first();
 }
 
-function SearchIcon({ toggleSearch }) {
+const SearchIcon = Scrivito.connect(({ toggleSearch }) => {
   if (
     Scrivito.currentPage() &&
     Scrivito.currentPage().objClass() === "SearchResults"
@@ -90,6 +90,6 @@ function SearchIcon({ toggleSearch }) {
       <i className="fa fa-search" aria-hidden="true" />
     </span>
   );
-}
+});
 
 export { SearchBox, SearchIcon };


### PR DESCRIPTION
The `SearchIcon` accesses `Scrivito.currentPage()`. This call
implicitely loads an `Scrivito.Obj` (unless already loaded).

A flaw in the current SDK doesn't enforce a `connect`, with the
disadvantage that nothing triggers the loading actually. If
`SearchIcon` where used alone, it would always fail to check
the current page's class.

Therefore we better have the example code on the safe and working side.

Note: If `SearchIcon` were used inside a `Scrivito.CurrentPage`, the
`Obj` would have been loaded, and the call to `Scrivito.currentPage()`
would yield a result. Because the SDK doesn't enforce `connect` for
loaded things, this would then "work" as expected.