### PR TITLE
Fixed styles of feature panel widget

### DIFF
--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1872,12 +1872,16 @@ section.navbar-fixed {
 }
 .card-theme.card-list .card-icon {
   text-align: center;
-  width: 22%;
+  width: 15%;
+  box-sizing: content-box;
   float: left;
+  padding: 20px 0;
+  line-height: 40px;
+  font-size: 25px;
 }
 .card-theme.card-list .card-body {
   text-align: left;
-  width: 78%;
+  width: 85%;
   float: left;
 }
 .card-theme.card-list .card-body h3 {


### PR DESCRIPTION
This PR fixes CSS bug in `feature panel` widget. 

before fix:
<img width="1043" alt="Screenshot 2019-06-25 at 12 58 35" src="https://user-images.githubusercontent.com/27221848/60093253-448cdd80-9749-11e9-962b-63249a457074.png">

after fix:
<img width="1038" alt="Screenshot 2019-06-25 at 12 59 21" src="https://user-images.githubusercontent.com/27221848/60093255-4656a100-9749-11e9-94d4-d4141ee3513a.png">
