### PR TITLE
[css] Corrected variable name zindex-modal-backdrop

### DIFF
--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -13,7 +13,7 @@ $border-radius-lg: 0 !default;
 $border-radius-sm: 0 !default;
 
 // use higher zindex, to avoid edit marker to be shown
-$zindex-modal-background: 100040 !default;
+$zindex-modal-backdrop: 100040 !default;
 $zindex-modal: 100050 !default;
 
 @mixin transition-performance() {


### PR DESCRIPTION
During the conversion from bootstrap 3 to 4 this got overlooked.

In "_modal.scss" the ".modal-backdrop" now defines the "z-index" using "$zindex-modal-backdrop"

Found threw `npx find-unused-sass-variables src/assets/stylesheets`