### PR TITLE
changed import order of index.scss

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import "./assets/stylesheets/index.scss";
 import "./polyfills";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
@@ -7,6 +6,7 @@ import "./Objs";
 import "./Widgets";
 import App from "./App";
 import "./config";
+import "./assets/stylesheets/index.scss";
 
 if (window.preloadDump) {
   Scrivito.preload(window.preloadDump).then(({ dumpLoaded }) => {


### PR DESCRIPTION
Import index.scss after Obj&Widgets to prevent overwriting styles while importing single scss files (like mixins, fontawesome etc.) into components.