### PR TITLE
Added link preconnect tag to cdn0.scrvt.com

### DIFF
--- a/public/_scrivito_extensions.html
+++ b/public/_scrivito_extensions.html
@@ -9,6 +9,7 @@
     <title>Scrivito Extensions</title>
     <link rel="preconnect" href="https://api.scrivito.com" crossorigin />
     <link rel="preconnect" href="https://api.scrivito.com" />
+    <link rel="preconnect" href="https://cdn0.scrvt.com" />
     <link rel="stylesheet" href="/index.css" />
   </head>
   <body>

--- a/public/catch_all_index.html
+++ b/public/catch_all_index.html
@@ -9,6 +9,7 @@
     <title>Your Scrivito powered site is loading ...</title>
     <link rel="preconnect" href="https://api.scrivito.com" crossorigin />
     <link rel="preconnect" href="https://api.scrivito.com" />
+    <link rel="preconnect" href="https://cdn0.scrvt.com" />
     <link rel="stylesheet" href="/index.css" />
 
     <script src="/js_snippets_head.js"></script>

--- a/src/prerenderContent/generateHtml.js
+++ b/src/prerenderContent/generateHtml.js
@@ -16,6 +16,7 @@ export default function generateHtml({
     ${headContent}
     <link rel="preconnect" href="https://api.scrivito.com" crossorigin />
     <link rel="preconnect" href="https://api.scrivito.com" />
+    <link rel="preconnect" href="https://cdn0.scrvt.com" />
     <link rel="stylesheet" href="/index.css" />
 
     <script src="/js_snippets_head.js"></script>


### PR DESCRIPTION
We preconnected via resource hints only to api.scrivito.com - this PR extends it also to cdn0.scrvt.com for performance reasons.