### PR TITLE
Fix image aspect ratio in social cards tab

### DIFF
--- a/src/assets/stylesheets/_social_cards.scss
+++ b/src/assets/stylesheets/_social_cards.scss
@@ -80,6 +80,7 @@
 .seo_card_img {
   max-height: 150px;
   margin-bottom: 10px;
+  width: auto;
 }
 
 // -- previews -- //


### PR DESCRIPTION
Scrivito 1.7.0 introduced progressive image loading.
For full compatibility, if the height of an `img` is set using CSS,
we should also specify a width.

#### Before
![image](https://user-images.githubusercontent.com/986170/66203300-4ea76c00-e6a8-11e9-97eb-24371b51a051.png)

#### After

![image](https://user-images.githubusercontent.com/986170/66203277-3b949c00-e6a8-11e9-94fc-73c8468afa5a.png)
