### PR TITLE
Inplace edit dates

### DIFF
--- a/src/Components/BlogPost/BlogPostDate.js
+++ b/src/Components/BlogPost/BlogPostDate.js
@@ -10,9 +10,15 @@ function BlogPostDate({ post }) {
   }
 
   return (
-    <time className="blog-timeline--badge" dateTime={date.toISOString()}>
+    <Scrivito.ContentTag
+      content={post}
+      attribute="publishedAt"
+      tag="time"
+      className="blog-timeline--badge"
+      dateTime={date.toISOString()}
+    >
       {formatDate(date, "mm/dd")}
-    </time>
+    </Scrivito.ContentTag>
   );
 }
 

--- a/src/Objs/Event/EventComponent.js
+++ b/src/Objs/Event/EventComponent.js
@@ -24,7 +24,14 @@ Scrivito.provideComponent("Event", ({ page }) => (
                 aria-hidden="true"
                 title="date"
               />{" "}
-              <EventDate date={page.get("date")} />
+              <Scrivito.ContentTag
+                content={page}
+                attribute="date"
+                tag="span"
+                className="event-info"
+              >
+                <EventDate date={page.get("date")} />
+              </Scrivito.ContentTag>
               <EventLocation event={page} />
             </h2>
           </div>
@@ -40,9 +47,7 @@ function EventDate({ date }) {
   if (!date) {
     return (
       <InPlaceEditingPlaceholder>
-        <span className="event-info">
-          Select a date in the event page properties.
-        </span>
+        Click to select a date.
       </InPlaceEditingPlaceholder>
     );
   }

--- a/src/Objs/Event/EventComponent.js
+++ b/src/Objs/Event/EventComponent.js
@@ -47,7 +47,7 @@ function EventDate({ date }) {
   if (!date) {
     return (
       <InPlaceEditingPlaceholder>
-        Click to select a date.
+        Click to select a date
       </InPlaceEditingPlaceholder>
     );
   }

--- a/src/Objs/Job/JobComponent.js
+++ b/src/Objs/Job/JobComponent.js
@@ -17,14 +17,20 @@ Scrivito.provideComponent("Job", ({ page }) => {
                 content={page}
                 attribute="title"
               />
-              <JobDatePosted datePosted={page.get("datePosted")} />
+              <Scrivito.ContentTag
+                content={page}
+                attribute="datePosted"
+                tag="span"
+              >
+                <JobDatePosted datePosted={page.get("datePosted")} />
+              </Scrivito.ContentTag>
             </div>
             <div className="col-lg-5 details-title-box">
               <JobLocation job={page} />
               <JobEmploymentTypes
                 employmentTypes={page.get("employmentType")}
               />
-              <JobValidThrough validThrough={page.get("validThrough")} />
+              <JobValidThrough page={page} />
             </div>
           </div>
         </div>
@@ -35,19 +41,38 @@ Scrivito.provideComponent("Job", ({ page }) => {
   );
 });
 
-const JobDatePosted = Scrivito.connect(({ datePosted }) => {
+function JobDatePosted({ datePosted }) {
   if (!datePosted) {
     return (
-      <InPlaceEditingPlaceholder block>
-        Select a date in the job page properties.
+      <InPlaceEditingPlaceholder>
+        Click to select posted at.
       </InPlaceEditingPlaceholder>
     );
   }
 
-  return <span>{formatDate(datePosted, "mm/dd/yyyy")}</span>;
-});
+  return formatDate(datePosted, "mm/dd/yyyy");
+}
 
-const JobValidThrough = Scrivito.connect(({ validThrough }) => {
+const JobValidThrough = Scrivito.connect(({ page }) => {
+  const validThrough = page.get("validThrough");
+  if (!validThrough) {
+    if (!Scrivito.isInPlaceEditingActive()) {
+      return null;
+    }
+
+    return (
+      <h2 className="h5">
+        <i className="fa fa-calendar-o fa-lg" aria-hidden="true" title="date" />{" "}
+        <span className="font-weight-bold">Valid through: </span>
+        <Scrivito.ContentTag content={page} attribute="validThrough" tag="span">
+          <InPlaceEditingPlaceholder>
+            Click to select expire at.
+          </InPlaceEditingPlaceholder>
+        </Scrivito.ContentTag>
+      </h2>
+    );
+  }
+
   if (!validThrough) {
     return (
       <InPlaceEditingPlaceholder block>
@@ -60,7 +85,9 @@ const JobValidThrough = Scrivito.connect(({ validThrough }) => {
     <h2 className="h5">
       <i className="fa fa-calendar-o fa-lg" aria-hidden="true" title="date" />{" "}
       <span className="font-weight-bold">Valid through: </span>
-      {formatDate(validThrough, "mm/dd/yyyy")}
+      <Scrivito.ContentTag content={page} attribute="validThrough" tag="span">
+        {formatDate(validThrough, "mm/dd/yyyy")}
+      </Scrivito.ContentTag>
     </h2>
   );
 });

--- a/src/Objs/Job/JobComponent.js
+++ b/src/Objs/Job/JobComponent.js
@@ -48,7 +48,7 @@ const JobDatePosted = Scrivito.connect(({ page }) => {
         formatDate(datePosted, "mm/dd/yyyy")
       ) : (
         <InPlaceEditingPlaceholder>
-          Click to select posted at.
+          Click to select a posting date
         </InPlaceEditingPlaceholder>
       )}
     </Scrivito.ContentTag>
@@ -71,7 +71,7 @@ const JobValidThrough = Scrivito.connect(({ page }) => {
           formatDate(validThrough, "mm/dd/yyyy")
         ) : (
           <InPlaceEditingPlaceholder>
-            Click to select expire at.
+            Click to select a date
           </InPlaceEditingPlaceholder>
         )}
       </Scrivito.ContentTag>

--- a/src/Objs/Job/JobComponent.js
+++ b/src/Objs/Job/JobComponent.js
@@ -38,6 +38,10 @@ Scrivito.provideComponent("Job", ({ page }) => {
 const JobDatePosted = Scrivito.connect(({ page }) => {
   const datePosted = page.get("datePosted");
 
+  if (!datePosted && !Scrivito.isInPlaceEditingActive()) {
+    return null;
+  }
+
   return (
     <Scrivito.ContentTag content={page} attribute="datePosted" tag="span">
       {datePosted ? (
@@ -53,22 +57,9 @@ const JobDatePosted = Scrivito.connect(({ page }) => {
 
 const JobValidThrough = Scrivito.connect(({ page }) => {
   const validThrough = page.get("validThrough");
-  if (!validThrough) {
-    if (!Scrivito.isInPlaceEditingActive()) {
-      return null;
-    }
 
-    return (
-      <h2 className="h5">
-        <i className="fa fa-calendar-o fa-lg" aria-hidden="true" title="date" />{" "}
-        <span className="font-weight-bold">Valid through: </span>
-        <Scrivito.ContentTag content={page} attribute="validThrough" tag="span">
-          <InPlaceEditingPlaceholder>
-            Click to select expire at.
-          </InPlaceEditingPlaceholder>
-        </Scrivito.ContentTag>
-      </h2>
-    );
+  if (!validThrough && !Scrivito.isInPlaceEditingActive()) {
+    return null;
   }
 
   return (
@@ -76,7 +67,13 @@ const JobValidThrough = Scrivito.connect(({ page }) => {
       <i className="fa fa-calendar-o fa-lg" aria-hidden="true" title="date" />{" "}
       <span className="font-weight-bold">Valid through: </span>
       <Scrivito.ContentTag content={page} attribute="validThrough" tag="span">
-        {formatDate(validThrough, "mm/dd/yyyy")}
+        {validThrough ? (
+          formatDate(validThrough, "mm/dd/yyyy")
+        ) : (
+          <InPlaceEditingPlaceholder>
+            Click to select expire at.
+          </InPlaceEditingPlaceholder>
+        )}
       </Scrivito.ContentTag>
     </h2>
   );

--- a/src/Objs/Job/JobComponent.js
+++ b/src/Objs/Job/JobComponent.js
@@ -17,13 +17,7 @@ Scrivito.provideComponent("Job", ({ page }) => {
                 content={page}
                 attribute="title"
               />
-              <Scrivito.ContentTag
-                content={page}
-                attribute="datePosted"
-                tag="span"
-              >
-                <JobDatePosted datePosted={page.get("datePosted")} />
-              </Scrivito.ContentTag>
+              <JobDatePosted page={page} />
             </div>
             <div className="col-lg-5 details-title-box">
               <JobLocation job={page} />
@@ -41,17 +35,21 @@ Scrivito.provideComponent("Job", ({ page }) => {
   );
 });
 
-function JobDatePosted({ datePosted }) {
-  if (!datePosted) {
-    return (
-      <InPlaceEditingPlaceholder>
-        Click to select posted at.
-      </InPlaceEditingPlaceholder>
-    );
-  }
+const JobDatePosted = Scrivito.connect(({ page }) => {
+  const datePosted = page.get("datePosted");
 
-  return formatDate(datePosted, "mm/dd/yyyy");
-}
+  return (
+    <Scrivito.ContentTag content={page} attribute="datePosted" tag="span">
+      {datePosted ? (
+        formatDate(datePosted, "mm/dd/yyyy")
+      ) : (
+        <InPlaceEditingPlaceholder>
+          Click to select posted at.
+        </InPlaceEditingPlaceholder>
+      )}
+    </Scrivito.ContentTag>
+  );
+});
 
 const JobValidThrough = Scrivito.connect(({ page }) => {
   const validThrough = page.get("validThrough");

--- a/src/Objs/Job/JobComponent.js
+++ b/src/Objs/Job/JobComponent.js
@@ -73,14 +73,6 @@ const JobValidThrough = Scrivito.connect(({ page }) => {
     );
   }
 
-  if (!validThrough) {
-    return (
-      <InPlaceEditingPlaceholder block>
-        Select a date in the job page properties.
-      </InPlaceEditingPlaceholder>
-    );
-  }
-
   return (
     <h2 className="h5">
       <i className="fa fa-calendar-o fa-lg" aria-hidden="true" title="date" />{" "}


### PR DESCRIPTION
It is now possible to edit dates of blog posts, jobs and events inplace:

<img width="1154" alt="inplace edit dates" src="https://user-images.githubusercontent.com/86275/66548673-04a80580-eb42-11e9-83e2-2bf18e1b63ba.png">

Please note, that you still have to use the page properties for a blog post without a date.