### PR TITLE
Introduce helmet-react-async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7871,6 +7871,18 @@
         "react-side-effect": "^1.1.0"
       }
     },
+    "react-helmet-async": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.4.tgz",
+      "integrity": "sha512-KTGHE9sz8N7+fCkZ2a3vzXH9eIkiTNhL2NhKR7XzzQl3WsGlCHh76arauJUIiGdfhjeMp7DY7PkASAmYFXeJYg==",
+      "requires": {
+        "@babel/runtime": "^7.3.4",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^2.0.4",
+        "shallowequal": "^1.1.0"
+      }
+    },
     "react-highlight-words": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/react-highlight-words/-/react-highlight-words-0.16.0.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-dom": "^16.8.6",
     "react-draggable": "^4.0.3",
     "react-helmet": "^5.2.1",
+    "react-helmet-async": "^1.0.4",
     "react-highlight-words": "^0.16.0",
     "react-images": "^0.5.19",
     "react-reveal": "^1.2.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,7 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
+import { HelmetProvider } from "react-helmet-async";
+
 import CurrentPageMetadata from "./Components/CurrentPageMetadata";
 import ErrorBoundary from "./Components/ErrorBoundary";
 import Footer from "./Components/Footer";
@@ -9,21 +11,25 @@ import NotFoundErrorPage from "./Components/NotFoundErrorPage";
 import CookieConsent from "./Components/CookieConsent";
 import Tracking from "./Components/Tracking";
 
+export const helmetContext = {};
+
 export default function App() {
   return (
     <ErrorBoundary>
-      <div>
-        <div className="content-wrapper">
-          <Navigation />
-          <Scrivito.CurrentPage />
-          <NotFoundErrorPage />
+      <HelmetProvider context={helmetContext}>
+        <div>
+          <div className="content-wrapper">
+            <Navigation />
+            <Scrivito.CurrentPage />
+            <NotFoundErrorPage />
+          </div>
+          <Footer />
+          <CurrentPageMetadata />
+          <CookieConsent />
+          <Tracking />
+          <Intercom />
         </div>
-        <Footer />
-        <CurrentPageMetadata />
-        <CookieConsent />
-        <Tracking />
-        <Intercom />
-      </div>
+      </HelmetProvider>
     </ErrorBoundary>
   );
 }

--- a/src/Components/CurrentPageMetadata.js
+++ b/src/Components/CurrentPageMetadata.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import Helmet from "react-helmet";
+import { Helmet } from "react-helmet-async";
 import getMetadata from "../utils/getMetadata";
 import favicon from "../assets/images/favicon.png";
 

--- a/src/Components/ErrorBoundary.js
+++ b/src/Components/ErrorBoundary.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Helmet from "react-helmet";
+import { Helmet } from "react-helmet-async";
 
 class ErrorBoundary extends React.Component {
   constructor(props) {

--- a/src/Components/Intercom.js
+++ b/src/Components/Intercom.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import Helmet from "react-helmet";
+import { Helmet } from "react-helmet-async";
 
 class Intercom extends React.Component {
   constructor(props) {

--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import Helmet from "react-helmet";
+import { Helmet } from "react-helmet-async";
 
 class NotFoundErrorPage extends React.Component {
   componentDidMount() {

--- a/src/Components/Tracking.js
+++ b/src/Components/Tracking.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import Helmet from "react-helmet";
+import { Helmet } from "react-helmet-async";
 import cookieConsentGiven from "../utils/cookieConsentGiven";
 
 export default function Tracking() {

--- a/src/prerenderContent/prerenderObj.js
+++ b/src/prerenderContent/prerenderObj.js
@@ -2,16 +2,15 @@
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
 import * as Scrivito from "scrivito";
-import Helmet from "react-helmet";
+import { HelmetProvider } from "react-helmet-async";
+
 import App, { helmetContext } from "../App";
 import filenameFromUrl from "./filenameFromUrl";
 import generateHtml from "./generateHtml";
 import generatePreloadDump from "./generatePreloadDump";
 
 export default async function prerenderObj(obj) {
-  // Tell helmet to pretend to run on a node server, not in a browser
-  // See https://github.com/nfl/react-helmet/issues/310 for details
-  Helmet.canUseDOM = false;
+  HelmetProvider.canUseDOM = false;
 
   const { result, preloadDump } = await Scrivito.renderPage(obj, () => {
     const bodyContent = ReactDOMServer.renderToString(<App />);

--- a/src/prerenderContent/prerenderObj.js
+++ b/src/prerenderContent/prerenderObj.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
 import * as Scrivito from "scrivito";
 import Helmet from "react-helmet";
-import App from "../App";
+import App, { helmetContext } from "../App";
 import filenameFromUrl from "./filenameFromUrl";
 import generateHtml from "./generateHtml";
 import generatePreloadDump from "./generatePreloadDump";
@@ -15,7 +15,7 @@ export default async function prerenderObj(obj) {
 
   const { result, preloadDump } = await Scrivito.renderPage(obj, () => {
     const bodyContent = ReactDOMServer.renderToString(<App />);
-    const helmet = Helmet.renderStatic();
+    const { helmet } = helmetContext;
 
     return {
       objId: obj.id(),


### PR DESCRIPTION
Type declaration file of `react-helmet-async` still uses obsolete `react-helmet` - see: https://github.com/staylor/react-helmet-async/blob/master/index.d.ts#L3
That's why I didn't remove it from dependencies. Maybe is there any safe-circumvention?

### Motivation

The package `react-helmet` seems to be outdated and no longer maintained. There is a fork by the New York Times, that addresses most of the known issues (`react-helmet-async`). See https://open.nytimes.com/the-future-of-meta-tag-management-for-modern-react-development-ec26a7dc9183 for the background on the fork.