### PR TITLE
404 bugfix

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -7,6 +7,6 @@
 /scrivito /scrivito/index.html 200
 
 # Single Page Application routes
-/404 /catch_all_index.html 404
+/* status-code=404-not-found /catch_all_index.html 404
 # PRERENDERED-UPPERCASE-ROUTES-PLACEHOLDER
 /* /catch_all_index.html 200

--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -8,9 +8,7 @@ class NotFoundErrorPage extends React.Component {
     const { search } = window.location;
 
     if (!Scrivito.isEditorLoggedIn() && !search.includes(statusCode)) {
-      window.location.search = search
-        ? `${search}&${statusCode}`
-        : `?${statusCode}`;
+      window.location.search = search ? `${search}&${statusCode}` : statusCode;
     }
   }
 

--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -4,10 +4,13 @@ import { Helmet } from "react-helmet-async";
 
 class NotFoundErrorPage extends React.Component {
   componentDidMount() {
-    const path = window.location.pathname;
+    const statusCode = "status-code=404-not-found";
+    const { search } = window.location;
 
-    if (!Scrivito.isEditorLoggedIn() && path !== "/404") {
-      window.location.replace(`/404?path=${encodeURIComponent(path)}`);
+    if (!Scrivito.isEditorLoggedIn() && !search.includes(statusCode)) {
+      window.location.search = search
+        ? `${search}&${statusCode}`
+        : `?${statusCode}`;
     }
   }
 

--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -6,7 +6,7 @@ class NotFoundErrorPage extends React.Component {
   componentDidMount() {
     const path = window.location.pathname;
 
-    if (path !== "/404") {
+    if (!Scrivito.isEditorLoggedIn() && path !== "/404") {
       window.location.replace(`/404?path=${encodeURIComponent(path)}`);
     }
   }


### PR DESCRIPTION
This PR does two things:

* Do not redirect on the 404 page, if in the Scrivito UI.
* Use a query param (a.k.a. "search") instead of the path for the 404 status code indicator. Also leave all other parts of the URL as is.