### PR TITLE
Refactoring: metadataPropertiesGroups

### DIFF
--- a/generator-scrivito/generators/obj/templates/XEditingConfig.js.ejs
+++ b/generator-scrivito/generators/obj/templates/XEditingConfig.js.ejs
@@ -4,7 +4,8 @@ import SectionWidget from "../../Widgets/SectionWidget/SectionWidgetClass";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
 
 Scrivito.provideEditingConfig("<%= objClassName %>", {
@@ -17,7 +18,7 @@ Scrivito.provideEditingConfig("<%= objClassName %>", {
     },
   },
   properties: ["title"],
-  propertiesGroups: [metadataPropertiesGroup],
+  propertiesGroups: [...metadataPropertiesGroups],
   initialContent: {
     body: [
       new SectionWidget({
@@ -26,4 +27,5 @@ Scrivito.provideEditingConfig("<%= objClassName %>", {
     ],
     ...metadataInitialContent,
   },
+  validations: [...metadataValidations],
 });

--- a/src/Objs/Author/AuthorEditingConfig.js
+++ b/src/Objs/Author/AuthorEditingConfig.js
@@ -3,9 +3,8 @@ import authorObjIcon from "../../assets/images/author_obj.svg";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
-  socialCardsPropertiesGroup,
-  socialCardsValidations,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
 
 Scrivito.provideEditingConfig("Author", {
@@ -24,13 +23,13 @@ Scrivito.provideEditingConfig("Author", {
     },
   },
   properties: ["title", "description", "image"],
-  propertiesGroups: [socialCardsPropertiesGroup, metadataPropertiesGroup],
+  propertiesGroups: [...metadataPropertiesGroups],
   initialContent: {
     ...metadataInitialContent,
     title: "Lorem Ipsum",
   },
   validations: [
-    ...socialCardsValidations,
+    ...metadataValidations,
     [
       "title",
 

--- a/src/Objs/Blog/BlogEditingConfig.js
+++ b/src/Objs/Blog/BlogEditingConfig.js
@@ -4,9 +4,8 @@ import SectionWidget from "../../Widgets/SectionWidget/SectionWidgetClass";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
-  socialCardsPropertiesGroup,
-  socialCardsValidations,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
 
 Scrivito.provideEditingConfig("Blog", {
@@ -25,10 +24,10 @@ Scrivito.provideEditingConfig("Blog", {
     },
   },
   properties: ["title", "navigationBackgroundImage"],
-  propertiesGroups: [socialCardsPropertiesGroup, metadataPropertiesGroup],
+  propertiesGroups: [...metadataPropertiesGroups],
   initialContent: {
     ...metadataInitialContent,
     body: [new SectionWidget({})],
   },
-  validations: [...socialCardsValidations],
+  validations: [...metadataValidations],
 });

--- a/src/Objs/BlogPost/BlogPostEditingConfig.js
+++ b/src/Objs/BlogPost/BlogPostEditingConfig.js
@@ -4,9 +4,8 @@ import SectionWidget from "../../Widgets/SectionWidget/SectionWidgetClass";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
-  socialCardsPropertiesGroup,
-  socialCardsValidations,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
 
 Scrivito.provideEditingConfig("BlogPost", {
@@ -32,7 +31,7 @@ Scrivito.provideEditingConfig("BlogPost", {
     },
   },
   properties: ["author", "publishedAt", "titleImage", "tags"],
-  propertiesGroups: [socialCardsPropertiesGroup, metadataPropertiesGroup],
+  propertiesGroups: [...metadataPropertiesGroups],
   initialContent: {
     ...metadataInitialContent,
     body: [new SectionWidget({})],
@@ -40,7 +39,7 @@ Scrivito.provideEditingConfig("BlogPost", {
     title: "Lorem Ipsum",
   },
   validations: [
-    ...socialCardsValidations,
+    ...metadataValidations,
     [
       "title",
 

--- a/src/Objs/Event/EventEditingConfig.js
+++ b/src/Objs/Event/EventEditingConfig.js
@@ -4,9 +4,8 @@ import SectionWidget from "../../Widgets/SectionWidget/SectionWidgetClass";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
-  socialCardsPropertiesGroup,
-  socialCardsValidations,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
 
 Scrivito.provideEditingConfig("Event", {
@@ -66,14 +65,14 @@ Scrivito.provideEditingConfig("Event", {
     "image",
     "tags",
   ],
-  propertiesGroups: [socialCardsPropertiesGroup, metadataPropertiesGroup],
+  propertiesGroups: [...metadataPropertiesGroups],
   initialContent: {
     ...metadataInitialContent,
     title: "Lorem Ipsum",
     body: [new SectionWidget({})],
   },
   validations: [
-    ...socialCardsValidations,
+    ...metadataValidations,
     [
       "title",
 

--- a/src/Objs/Homepage/HomepageEditingConfig.js
+++ b/src/Objs/Homepage/HomepageEditingConfig.js
@@ -4,7 +4,7 @@ import {
   defaultPageEditingConfigAttributes,
   defaultPageInitialContent,
   defaultPageProperties,
-  defaultPageTitleValidations,
+  defaultPageValidations,
 } from "../_defaultPageEditingConfig";
 import {
   metadataEditingConfigAttributes,
@@ -95,5 +95,5 @@ Scrivito.provideEditingConfig("Homepage", {
     ...metadataInitialContent,
     showAsLandingPage: "no",
   },
-  validations: [...defaultPageTitleValidations, ...metadataValidations],
+  validations: [...defaultPageValidations, ...metadataValidations],
 });

--- a/src/Objs/Homepage/HomepageEditingConfig.js
+++ b/src/Objs/Homepage/HomepageEditingConfig.js
@@ -4,14 +4,13 @@ import {
   defaultPageEditingConfigAttributes,
   defaultPageInitialContent,
   defaultPageProperties,
-  defaultPageTitleValidation,
+  defaultPageTitleValidations,
 } from "../_defaultPageEditingConfig";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
-  socialCardsPropertiesGroup,
-  socialCardsValidations,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
 
 Scrivito.provideEditingConfig("Homepage", {
@@ -89,13 +88,12 @@ Scrivito.provideEditingConfig("Homepage", {
         "intercomAppId",
       ],
     },
-    socialCardsPropertiesGroup,
-    metadataPropertiesGroup,
+    ...metadataPropertiesGroups,
   ],
   initialContent: {
     ...defaultPageInitialContent,
     ...metadataInitialContent,
     showAsLandingPage: "no",
   },
-  validations: [defaultPageTitleValidation, ...socialCardsValidations],
+  validations: [...defaultPageTitleValidations, ...metadataValidations],
 });

--- a/src/Objs/Job/JobEditingConfig.js
+++ b/src/Objs/Job/JobEditingConfig.js
@@ -4,9 +4,8 @@ import SectionWidget from "../../Widgets/SectionWidget/SectionWidgetClass";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
-  socialCardsPropertiesGroup,
-  socialCardsValidations,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
 
 Scrivito.provideEditingConfig("Job", {
@@ -86,14 +85,14 @@ Scrivito.provideEditingConfig("Job", {
     "locationCountry",
     "employmentType",
   ],
-  propertiesGroups: [socialCardsPropertiesGroup, metadataPropertiesGroup],
+  propertiesGroups: [...metadataPropertiesGroups],
   initialContent: {
     ...metadataInitialContent,
     title: "Lorem Ipsum",
     body: [new SectionWidget({})],
   },
   validations: [
-    ...socialCardsValidations,
+    ...metadataValidations,
     [
       "title",
 

--- a/src/Objs/LandingPage/LandingPageEditingConfig.js
+++ b/src/Objs/LandingPage/LandingPageEditingConfig.js
@@ -4,14 +4,13 @@ import {
   defaultPageEditingConfigAttributes,
   defaultPageInitialContent,
   defaultPageProperties,
-  defaultPageTitleValidation,
+  defaultPageTitleValidations,
 } from "../_defaultPageEditingConfig";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
-  socialCardsPropertiesGroup,
-  socialCardsValidations,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
 
 Scrivito.provideEditingConfig("LandingPage", {
@@ -22,10 +21,10 @@ Scrivito.provideEditingConfig("LandingPage", {
     ...metadataEditingConfigAttributes,
   },
   properties: [...defaultPageProperties],
-  propertiesGroups: [socialCardsPropertiesGroup, metadataPropertiesGroup],
+  propertiesGroups: [...metadataPropertiesGroups],
   initialContent: {
     ...defaultPageInitialContent,
     ...metadataInitialContent,
   },
-  validations: [defaultPageTitleValidation, ...socialCardsValidations],
+  validations: [...defaultPageTitleValidations, ...metadataValidations],
 });

--- a/src/Objs/LandingPage/LandingPageEditingConfig.js
+++ b/src/Objs/LandingPage/LandingPageEditingConfig.js
@@ -4,7 +4,7 @@ import {
   defaultPageEditingConfigAttributes,
   defaultPageInitialContent,
   defaultPageProperties,
-  defaultPageTitleValidations,
+  defaultPageValidations,
 } from "../_defaultPageEditingConfig";
 import {
   metadataEditingConfigAttributes,
@@ -26,5 +26,5 @@ Scrivito.provideEditingConfig("LandingPage", {
     ...defaultPageInitialContent,
     ...metadataInitialContent,
   },
-  validations: [...defaultPageTitleValidations, ...metadataValidations],
+  validations: [...defaultPageValidations, ...metadataValidations],
 });

--- a/src/Objs/Page/PageEditingConfig.js
+++ b/src/Objs/Page/PageEditingConfig.js
@@ -4,14 +4,13 @@ import {
   defaultPageEditingConfigAttributes,
   defaultPageInitialContent,
   defaultPageProperties,
-  defaultPageTitleValidation,
+  defaultPageTitleValidations,
 } from "../_defaultPageEditingConfig";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
-  socialCardsPropertiesGroup,
-  socialCardsValidations,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
 
 Scrivito.provideEditingConfig("Page", {
@@ -22,10 +21,10 @@ Scrivito.provideEditingConfig("Page", {
     ...metadataEditingConfigAttributes,
   },
   properties: [...defaultPageProperties],
-  propertiesGroups: [socialCardsPropertiesGroup, metadataPropertiesGroup],
+  propertiesGroups: [...metadataPropertiesGroups],
   initialContent: {
     ...defaultPageInitialContent,
     ...metadataInitialContent,
   },
-  validations: [defaultPageTitleValidation, ...socialCardsValidations],
+  validations: [...defaultPageTitleValidations, ...metadataValidations],
 });

--- a/src/Objs/Page/PageEditingConfig.js
+++ b/src/Objs/Page/PageEditingConfig.js
@@ -4,7 +4,7 @@ import {
   defaultPageEditingConfigAttributes,
   defaultPageInitialContent,
   defaultPageProperties,
-  defaultPageTitleValidations,
+  defaultPageValidations,
 } from "../_defaultPageEditingConfig";
 import {
   metadataEditingConfigAttributes,
@@ -26,5 +26,5 @@ Scrivito.provideEditingConfig("Page", {
     ...defaultPageInitialContent,
     ...metadataInitialContent,
   },
-  validations: [...defaultPageTitleValidations, ...metadataValidations],
+  validations: [...defaultPageValidations, ...metadataValidations],
 });

--- a/src/Objs/SearchResults/SearchResultsEditingConfig.js
+++ b/src/Objs/SearchResults/SearchResultsEditingConfig.js
@@ -3,11 +3,10 @@ import SearchResultsObjIcon from "../../assets/images/search_results_obj.svg";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,
-  metadataPropertiesGroup,
-  socialCardsPropertiesGroup,
-  socialCardsValidations,
+  metadataPropertiesGroups,
+  metadataValidations,
 } from "../_metadataEditingConfig";
-import { defaultPageTitleValidation } from "../_defaultPageEditingConfig";
+import { defaultPageTitleValidations } from "../_defaultPageEditingConfig";
 
 Scrivito.provideEditingConfig("SearchResults", {
   title: "Search Results",
@@ -25,9 +24,9 @@ Scrivito.provideEditingConfig("SearchResults", {
     },
   },
   properties: ["title", "navigationBackgroundImage"],
-  propertiesGroups: [socialCardsPropertiesGroup, metadataPropertiesGroup],
+  propertiesGroups: [...metadataPropertiesGroups],
   initialContent: {
     ...metadataInitialContent,
   },
-  validations: [defaultPageTitleValidation, ...socialCardsValidations],
+  validations: [...defaultPageTitleValidations, ...metadataValidations],
 });

--- a/src/Objs/SearchResults/SearchResultsEditingConfig.js
+++ b/src/Objs/SearchResults/SearchResultsEditingConfig.js
@@ -6,7 +6,7 @@ import {
   metadataPropertiesGroups,
   metadataValidations,
 } from "../_metadataEditingConfig";
-import { defaultPageTitleValidations } from "../_defaultPageEditingConfig";
+import { defaultPageValidations } from "../_defaultPageEditingConfig";
 
 Scrivito.provideEditingConfig("SearchResults", {
   title: "Search Results",
@@ -28,5 +28,5 @@ Scrivito.provideEditingConfig("SearchResults", {
   initialContent: {
     ...metadataInitialContent,
   },
-  validations: [...defaultPageTitleValidations, ...metadataValidations],
+  validations: [...defaultPageValidations, ...metadataValidations],
 });

--- a/src/Objs/_defaultPageEditingConfig.js
+++ b/src/Objs/_defaultPageEditingConfig.js
@@ -46,7 +46,7 @@ export const defaultPageProperties = [
   "navigationBackgroundImageGradient",
 ];
 
-export const defaultPageTitleValidations = [
+export const defaultPageValidations = [
   [
     "title",
 

--- a/src/Objs/_defaultPageEditingConfig.js
+++ b/src/Objs/_defaultPageEditingConfig.js
@@ -46,15 +46,17 @@ export const defaultPageProperties = [
   "navigationBackgroundImageGradient",
 ];
 
-export const defaultPageTitleValidation = [
-  "title",
+export const defaultPageTitleValidations = [
+  [
+    "title",
 
-  title => {
-    if (title.length === 0) {
-      return {
-        message: "The title should be set.",
-        severity: "warning",
-      };
-    }
-  },
+    title => {
+      if (title.length === 0) {
+        return {
+          message: "The title should be set.",
+          severity: "warning",
+        };
+      }
+    },
+  ],
 ];

--- a/src/Objs/_metadataEditingConfig.js
+++ b/src/Objs/_metadataEditingConfig.js
@@ -17,18 +17,19 @@ export const metadataInitialContent = {
   robotsIndex: "yes",
 };
 
-export const metadataPropertiesGroup = {
-  title: "Metadata",
-  properties: ["metaDataDescription", "robotsIndex"],
-};
+export const metadataPropertiesGroups = [
+  {
+    title: "Metadata",
+    properties: ["metaDataDescription", "robotsIndex"],
+  },
+  {
+    title: "Social cards",
+    component: "SocialCardsTab",
+    properties: ["tcCreator", "tcDescription", "ogDescription"],
+  },
+];
 
-export const socialCardsPropertiesGroup = {
-  title: "Social cards",
-  component: "SocialCardsTab",
-  properties: ["tcCreator", "tcDescription", "ogDescription"],
-};
-
-export const socialCardsValidations = [
+export const metadataValidations = [
   [
     "tcCreator",
 


### PR DESCRIPTION
### Refactoring:
merge `socialCardsPropertiesGroup` and `metadataPropertiesGroup`into new `metadataPropertiesGroups`
merge `socialCardsValidations` in `metadataValidations` (preperation)
wrapped `defaultPageTitleValidation` in an array and renamed it to `defaultPageTitleValidations`
added `validations` to `XEditingConfig.js.ejs `