### PR TITLE
[webpack] Bugfix: Deep Clone headersCsp in devServerCspHeaders.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "is-empty": "^1.2.0",
     "jquery": "^3.4.1",
     "jsontoxml": "^1.0.1",
+    "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
     "mini-css-extract-plugin": "^0.9.0",
     "moment-from-now": "0.0.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const dotenv = require("dotenv");
 const path = require("path");
 const process = require("process");
 const webpack = require("webpack");
+const lodash = require("lodash");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
@@ -204,7 +205,7 @@ function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
 }
 
 function devServerCspHeader() {
-  const directives = deepClone(headersCsp);
+  const directives = lodash.cloneDeep(headersCsp);
 
   // allow 'unsafe-eval' for webpack hot code reloading
   directives["script-src"].push("'unsafe-eval'");
@@ -213,10 +214,6 @@ function devServerCspHeader() {
   directives["default-src"].push("ws:");
 
   return builder({ directives });
-}
-
-function deepClone(object) {
-  return JSON.parse(JSON.stringify(object));
 }
 
 module.exports = webpackConfig;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -204,7 +204,7 @@ function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
 }
 
 function devServerCspHeader() {
-  const directives = Object.assign({}, headersCsp);
+  const directives = deepClone(headersCsp);
 
   // allow 'unsafe-eval' for webpack hot code reloading
   directives["script-src"].push("'unsafe-eval'");
@@ -213,6 +213,10 @@ function devServerCspHeader() {
   directives["default-src"].push("ws:");
 
   return builder({ directives });
+}
+
+function deepClone(object) {
+  return JSON.parse(JSON.stringify(object));
 }
 
 module.exports = webpackConfig;


### PR DESCRIPTION
Otherwise `devServerCspHeaders` modifies `headersCsp` directly and adds `"'unsafe-eval'"` to `script-src`!