### PR TITLE
Discontinue page description validations.

### DIFF
--- a/src/Objs/_metadataEditingConfig.js
+++ b/src/Objs/_metadataEditingConfig.js
@@ -34,13 +34,7 @@ export const metadataValidations = [
     "metaDataDescription",
 
     metaDataDescription => {
-      if (!metaDataDescription) {
-        return {
-          message: "Providing a page description is recommended.",
-          severity: "info",
-        };
-      }
-      if (metaDataDescription.length > 175) {
+      if (metaDataDescription && metaDataDescription.length > 175) {
         return {
           message: "The page description should not exceed 175 characters.",
           severity: "warning",


### PR DESCRIPTION
After some discussion we decided to no longer recommend writing page descriptions.

Google is usually smart enough to pick up a reasonable description from the content of the page.