### PR TITLE
Scrivito 1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9006,12 +9006,12 @@
       "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
     },
     "scrivito": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/scrivito/-/scrivito-1.11.0.tgz",
-      "integrity": "sha512-ZT4swfgypJubIjJBw0v037UCQSKil6DM7ToXDUVtEFKn4MIqqka5fdv44hFwYL2CyWWvwrAjLtBNyDHsXAXFlQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/scrivito/-/scrivito-1.12.0.tgz",
+      "integrity": "sha512-tTlCffDNB+noBcTsfxBIWGaqctB/kwGN+eRJR1M1gXzArE4C2IG5PA1iWT3iXLLYoXSbB6kwCpL1OwEU6PBLvw==",
       "requires": {
-        "history": "^4.9.0",
-        "promise-polyfill": "^8.1.0",
+        "history": "^4.10.1",
+        "promise-polyfill": "^8.1.3",
         "speakingurl": "^14.0.1",
         "tcomb": ">=3.2.29",
         "tcomb-react": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-slick": "^0.25.2",
     "reactstrap": "^8.4.1",
     "sass-loader": "^8.0.2",
-    "scrivito": "^1.11.0",
+    "scrivito": "^1.12.0",
     "slick-carousel": "^1.6.0",
     "terser-webpack-plugin": "^2.3.5",
     "typescript": "^3.8.3",


### PR DESCRIPTION
Updated Scrivito to 1.12.0.

See https://www.scrivito.com/scrivito-js-1-12-0-released-featuring-workflows-and-page-history-a2ee76c7cbe41945 for details about the release.