### PR TITLE
[csp] Added "frame-ancestors" policy.

### DIFF
--- a/public/_headersCsp.json
+++ b/public/_headersCsp.json
@@ -13,5 +13,5 @@
   ],
   "object-src": "'none'",
   "block-all-mixed-content": true,
-  "frame-ancestors": ["'self'", "https://edit.scrivito.com"]
+  "frame-ancestors": ["'self'", "https://*.scrivito.com"]
 }

--- a/public/_headersCsp.json
+++ b/public/_headersCsp.json
@@ -12,5 +12,6 @@
     "https://www.google-analytics.com"
   ],
   "object-src": "'none'",
-  "block-all-mixed-content": true
+  "block-all-mixed-content": true,
+  "frame-ancestors": ["'self'", "https://edit.scrivito.com"]
 }


### PR DESCRIPTION
This is the newer version of the deprecated "X-Frame-Options" header.

This PR also white-lists `https://*.scrivito.com` which will soon be a new place to edit scrivito content.