### PR TITLE
Add 'loading="lazy"' to all iframes.

### DIFF
--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
@@ -127,6 +127,7 @@ function InteractiveMap({ address, apiKey, zoom, mapType }) {
       frameBorder="0"
       style={{ border: 0 }}
       src={url}
+      loading="lazy"
     />
   );
 }

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
@@ -30,6 +30,7 @@ Scrivito.provideComponent("VimeoVideoWidget", ({ widget }) => {
         allowFullScreen
         webkitallowfullscreen="true"
         mozallowfullscreen="true"
+        loading="lazy"
       />
     </div>
   );

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
@@ -31,6 +31,7 @@ Scrivito.provideComponent("YoutubeVideoWidget", ({ widget }) => {
         allowFullScreen
         webkitallowfullscreen="true"
         mozallowfullscreen="true"
+        loading="lazy"
       />
     </div>
   );


### PR DESCRIPTION
This allows to save the bandwidth, since the iframe is only loaded once being near the viewport. Browsers that do not support this feature simply ignore this attribute.

See https://web.dev/iframe-lazy-loading/ for more details.

This saves around ~500 KB on initial page load *per YouTube or Vimeo* widget. So having two of these widget on page page saves ~1000 KB.