### PR TITLE
react-images => react-bnb-gallery + code splitting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1025,6 +1025,16 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@loadable/component": {
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/@loadable/component/-/component-5.13.2.tgz",
+      "integrity": "sha512-eCtJhCFfUg7dzEBc5O4ZNfG0wftCLVSzpfOw9qPYJ16T/bmvrGRDdY8q/ARM4o90MOFlJzIRepnuXnqxB5ZUyQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.7",
+        "hoist-non-react-statics": "^3.3.1",
+        "react-is": "^16.12.0"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -5800,6 +5810,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "homedir-polyfill": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1563,15 +1563,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "aphrodite": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/aphrodite/-/aphrodite-0.5.0.tgz",
-      "integrity": "sha1-pLmokCZiOV0nAucKx6K0ymbyVwM=",
-      "requires": {
-        "asap": "^2.0.3",
-        "inline-style-prefixer": "^2.0.0"
-      }
-    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -1778,11 +1769,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -2212,11 +2198,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-    },
-    "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4614,11 +4595,6 @@
         }
       }
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
-    },
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
@@ -6098,11 +6074,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
-    "hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6195,15 +6166,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "inline-style-prefixer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
-      "integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
-      "requires": {
-        "bowser": "^1.0.0",
-        "hyphenate-style-name": "^1.0.1"
-      }
     },
     "inquirer": {
       "version": "1.2.3",
@@ -9075,17 +9037,6 @@
         "prop-types": "^15.5.8"
       }
     },
-    "react-images": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/react-images/-/react-images-0.5.19.tgz",
-      "integrity": "sha512-B3d4W1uFJj+m17K8S65iAyEJShKGBjPk7n7N1YsPiAydEm8mIq9a6CoeQFMY1d7N2QMs6FBCjT9vELyc5jP5JA==",
-      "requires": {
-        "aphrodite": "^0.5.0",
-        "prop-types": "^15.6.0",
-        "react-scrolllock": "^2.0.1",
-        "react-transition-group": "2"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9118,26 +9069,12 @@
         "prop-types": "^15.5.8"
       }
     },
-    "react-prop-toggle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-prop-toggle/-/react-prop-toggle-1.0.2.tgz",
-      "integrity": "sha512-JmerjAXs7qJ959+d0Ygt7Cb2+4fG+n3I2VXO6JO0AcAY1vkRN/JpZKAN67CMXY889xEJcfylmMPhzvf6nWO68Q=="
-    },
     "react-reveal-iframe": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/react-reveal-iframe/-/react-reveal-iframe-1.2.7.tgz",
       "integrity": "sha512-ZZBKQlpaL81eqw3lPTPn26vSpcNpUxe4x7aAO10vtxbl/QuOhJhFe1HJcbjYzymyCIU4drClpNxcUm2f4q/WgQ==",
       "requires": {
         "prop-types": "^15.7.2"
-      }
-    },
-    "react-scrolllock": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-2.0.7.tgz",
-      "integrity": "sha512-Gzpu8+ulxdYcybAgJOFTXc70xs7SBZDQbZNpKzchZUgLCJKjz6lrgESx6LHHZgfELx1xYL4yHu3kYQGQPFas/g==",
-      "requires": {
-        "exenv": "^1.2.2",
-        "react-prop-toggle": "^1.0.2"
       }
     },
     "react-slick": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1470,6 +1470,22 @@
         "indent-string": "^4.0.0"
       }
     },
+    "airbnb-prop-types": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
+      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
+      "requires": {
+        "array.prototype.find": "^2.1.1",
+        "function.prototype.name": "^1.1.2",
+        "is-regex": "^1.1.0",
+        "object-is": "^1.1.2",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.2",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.13.1"
+      }
+    },
     "ajv": {
       "version": "6.12.5",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
@@ -1669,6 +1685,35 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "array.prototype.find": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
+      "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.4"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
     },
     "array.prototype.flat": {
       "version": "1.2.3",
@@ -5142,6 +5187,23 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focus-trap": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-5.1.0.tgz",
+      "integrity": "sha512-CkB/nrO55069QAUjWFBpX6oc+9V90Qhgpe6fBWApzruMq5gnlh90Oo7iSSDK7pKiV5ugG6OY2AXM5mxcmL3lwQ==",
+      "requires": {
+        "tabbable": "^4.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "focus-trap-react": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-7.0.1.tgz",
+      "integrity": "sha512-12TxHtVntj/sCsT3bwB3pPK+3rACMFLO7LBfk4nKrw1HERRmO/oc0+woD9vZKffxo5zkxkz9amc9rou9reVnpA==",
+      "requires": {
+        "focus-trap": "^5.1.0"
+      }
+    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
@@ -5290,10 +5352,45 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "function.prototype.name": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
+      "integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "functions-have-names": "^1.2.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "functions-have-names": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.1.tgz",
+      "integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA=="
     },
     "fuse.js": {
       "version": "6.4.1",
@@ -8659,6 +8756,16 @@
         "react-is": "^16.8.1"
       }
     },
+    "prop-types-exact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "requires": {
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "reflect.ownkeys": "^0.2.0"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -8888,6 +8995,31 @@
         "scheduler": "^0.13.6"
       }
     },
+    "react-bnb-gallery": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/react-bnb-gallery/-/react-bnb-gallery-1.4.4.tgz",
+      "integrity": "sha512-shD4GuIqAS03Xe2k4XEqLBQV/JkZG1ywJqc2fwKN9REj20vOjRhs4Vsbt3yBXbzbgPD1sPdBWfEdM1ZCMXKBIw==",
+      "requires": {
+        "airbnb-prop-types": "^2.16.0",
+        "ajv": "^6.12.3",
+        "classnames": "^2.2.6",
+        "focus-trap-react": "^7.0.1",
+        "lodash": "^4.17.19",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "react-portal": "^4.2.1",
+        "typescript": "^3.6.2"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.7",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+          "optional": true
+        }
+      }
+    },
     "react-cookie-consent": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-5.1.3.tgz",
@@ -8976,6 +9108,14 @@
         "prop-types": "^15.6.1",
         "typed-styles": "^0.0.7",
         "warning": "^4.0.2"
+      }
+    },
+    "react-portal": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
+      "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
+      "requires": {
+        "prop-types": "^15.5.8"
       }
     },
     "react-prop-toggle": {
@@ -9167,6 +9307,11 @@
           }
         }
       }
+    },
+    "reflect.ownkeys": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
     },
     "regenerate": {
       "version": "1.4.1",
@@ -10514,6 +10659,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "tabbable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
+      "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ=="
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   },
   "dependencies": {
     "@babel/core": "^7.11.6",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
+    "@loadable/component": "^5.13.2",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "autotrack": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "prettier": "^2.1.1",
     "puppeteer": "^5.3.0",
     "react": "^16.8.6",
+    "react-bnb-gallery": "^1.4.4",
     "react-cookie-consent": "^5.1.3",
     "react-dom": "^16.8.6",
     "react-draggable": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react-draggable": "^4.4.3",
     "react-helmet-async": "^1.0.7",
     "react-highlight-words": "^0.16.0",
-    "react-images": "^0.5.19",
     "react-reveal-iframe": "^1.2.7",
     "react-slick": "^0.27.11",
     "reactstrap": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.11.6",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@loadable/component": "^5.13.2",

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidget.scss
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidget.scss
@@ -100,6 +100,7 @@
   }
 }
 
+.gallery-modal .gallery-modal--overlay { background: rgba(22,22,22,.9)!important; }
 .gallery-modal .gallery-modal--container {
   .gallery-thumbnails--toggle {
     visibility: hidden;
@@ -108,6 +109,7 @@
     border: none;
   }
   .photo-caption {
+    font-family: "Source Sans Pro", sans-serif;
     color: white;
   }
 }

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidget.scss
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidget.scss
@@ -1,3 +1,4 @@
+@import "~react-bnb-gallery/dist/style.css";
 @import "src/assets/stylesheets/variables";
 @import "src/assets/stylesheets/mixins";
 @import "src/assets/stylesheets/bootstrap/functions";
@@ -96,6 +97,18 @@
     max-height: 0;
     max-width: 0;
     opacity: 0;
+  }
+}
+
+.gallery-modal .gallery-modal--container {
+  .gallery-thumbnails--toggle {
+    visibility: hidden;
+  }
+  button.thumbnail-button {
+    border: none;
+  }
+  .photo-caption {
+    color: white;
   }
 }
 

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidget.scss
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidget.scss
@@ -100,7 +100,6 @@
   }
 }
 
-.gallery-modal .gallery-modal--overlay { background: rgba(22,22,22,.9)!important; }
 .gallery-modal .gallery-modal--container {
   .gallery-thumbnails--toggle {
     visibility: hidden;

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -1,12 +1,14 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import ReactBnbGallery from "react-bnb-gallery";
+import loadable from "@loadable/component";
 
 import fullScreenWidthPixels from "../../utils/fullScreenWidthPixels";
 import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
 import TagList from "../../Components/TagList";
 import isImage from "../../utils/isImage";
 import "./ThumbnailGalleryWidget.scss";
+
+const ReactBnbGallery = loadable(() => import("react-bnb-gallery"));
 
 class ThumbnailGalleryComponent extends React.Component {
   constructor(props) {

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import Lightbox from "react-images";
+import ReactBnbGallery from "react-bnb-gallery";
 
 import fullScreenWidthPixels from "../../utils/fullScreenWidthPixels";
 import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
@@ -19,9 +19,6 @@ class ThumbnailGalleryComponent extends React.Component {
 
     this.openLightbox = this.openLightbox.bind(this);
     this.closeLightbox = this.closeLightbox.bind(this);
-    this.gotoPrevious = this.gotoPrevious.bind(this);
-    this.gotoNext = this.gotoNext.bind(this);
-    this.gotoImage = this.gotoImage.bind(this);
     this.setTag = this.setTag.bind(this);
   }
 
@@ -37,24 +34,6 @@ class ThumbnailGalleryComponent extends React.Component {
     this.setState({
       currentImage: 0,
       lightboxIsOpen: false,
-    });
-  }
-
-  gotoPrevious() {
-    this.setState({
-      currentImage: this.state.currentImage - 1,
-    });
-  }
-
-  gotoNext() {
-    this.setState({
-      currentImage: this.state.currentImage + 1,
-    });
-  }
-
-  gotoImage(index) {
-    this.setState({
-      currentImage: index,
     });
   }
 
@@ -98,17 +77,12 @@ class ThumbnailGalleryComponent extends React.Component {
               />
             ))}
           </div>
-          <Lightbox
-            images={lightboxImages}
-            currentImage={this.state.currentImage}
-            isOpen={this.state.lightboxIsOpen}
-            onClickImage={this.handleClickImage}
-            onClickNext={this.gotoNext}
-            onClickPrev={this.gotoPrevious}
-            onClickThumbnail={this.gotoImage}
+          <ReactBnbGallery
+            show={this.state.lightboxIsOpen}
+            activePhotoIndex={this.state.currentImage}
+            photos={lightboxImages}
             onClose={this.closeLightbox}
-            showThumbnails
-            backdropClosesModal
+            wrap={false}
           />
         </div>
       </div>
@@ -178,7 +152,7 @@ function lightboxOptions(galleryImageWidget) {
   const alt = image.get("alternativeText");
 
   return {
-    src: srcUrl,
+    photo: srcUrl,
     thumbnail: srcUrl,
     caption: [
       galleryImageWidget.get("title"),

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -81,6 +81,7 @@ class ThumbnailGalleryComponent extends React.Component {
           </div>
           <ReactBnbGallery
             show={this.state.lightboxIsOpen}
+            backgroundColor="rgba(22,22,22,.9)"
             activePhotoIndex={this.state.currentImage}
             photos={lightboxImages}
             onClose={this.closeLightbox}

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -82,6 +82,7 @@ class ThumbnailGalleryComponent extends React.Component {
           <ReactBnbGallery
             show={this.state.lightboxIsOpen}
             backgroundColor="rgba(22,22,22,.9)"
+            zIndex={1000000} // same value as react-cookie-consent
             activePhotoIndex={this.state.currentImage}
             photos={lightboxImages}
             onClose={this.closeLightbox}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,7 +79,6 @@ function webpackConfig(env = {}) {
                     },
                   ],
                 ],
-                plugins: ["@babel/plugin-syntax-dynamic-import"],
                 cacheDirectory: "tmp/babel-cache",
               },
             },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,6 +79,7 @@ function webpackConfig(env = {}) {
                     },
                   ],
                 ],
+                plugins: ["@babel/plugin-syntax-dynamic-import"],
                 cacheDirectory: "tmp/babel-cache",
               },
             },
@@ -115,7 +116,7 @@ function webpackConfig(env = {}) {
           ? "[name].js"
           : "assets/[name].[contenthash].js";
       },
-
+      chunkFilename: "assets/chunk-[id].[contenthash].js",
       path: path.join(__dirname, buildPath),
     },
     plugins: generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }),


### PR DESCRIPTION
`ThumbnailGallery` previously used [`react-images`](https://www.npmjs.com/package/react-images). Now it uses [`react-bnb-gallery`](https://www.npmjs.com/package/react-bnb-gallery).

According to [`react-images`](https://www.npmjs.com/package/react-images)'s own readme:

> ⚠️  Warning!
>
> Don't use this in a new project. This package hasn't been properly maintained in a long time and there are much better options available.

So we needed a replacement.

Thankfully @pietruszka found a good library, that is quite an easy replacement: [`react-bnb-gallery`](https://www.npmjs.com/package/react-bnb-gallery). It works very similar to `react-images` and with a few tweaks looks at least similar.

### File size

To address filesize concerns about `react-bnb-gallery` we introduces code-splitting to cut of this part from the rest of javascript. The gallery only needs to be loaded, after a click happend.

### Screenshots

*Previously*
<img width="1552" alt="react-images" src="https://user-images.githubusercontent.com/86275/93215496-c9a54d80-f766-11ea-9f52-84f2fd52f64e.png">

*Now*
<img width="1552" alt="react-bnb-gallery v2" src="https://user-images.githubusercontent.com/86275/93439340-b8775080-f8ce-11ea-9b27-2b5bd693895d.png">

### Open Todos
* [x] Check if it works fine with latest react version (without warnings)
* [x] Check if it works fine with IE11.
* [x] Check bundle size (from 999kb to 954kb)
* [x] Fine tune design by Alex G.