### PR TITLE
react-reveal => react-reveal-iframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8983,12 +8983,12 @@
       "resolved": "https://registry.npmjs.org/react-prop-toggle/-/react-prop-toggle-1.0.2.tgz",
       "integrity": "sha512-JmerjAXs7qJ959+d0Ygt7Cb2+4fG+n3I2VXO6JO0AcAY1vkRN/JpZKAN67CMXY889xEJcfylmMPhzvf6nWO68Q=="
     },
-    "react-reveal": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-reveal/-/react-reveal-1.2.2.tgz",
-      "integrity": "sha512-JCv3fAoU6Z+Lcd8U48bwzm4pMZ79qsedSXYwpwt6lJNtj/v5nKJYZZbw3yhaQPPgYePo3Y0NOCoYOq/jcsisuw==",
+    "react-reveal-iframe": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/react-reveal-iframe/-/react-reveal-iframe-1.2.7.tgz",
+      "integrity": "sha512-ZZBKQlpaL81eqw3lPTPn26vSpcNpUxe4x7aAO10vtxbl/QuOhJhFe1HJcbjYzymyCIU4drClpNxcUm2f4q/WgQ==",
       "requires": {
-        "prop-types": "^15.5.10"
+        "prop-types": "^15.7.2"
       }
     },
     "react-scrolllock": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-helmet-async": "^1.0.7",
     "react-highlight-words": "^0.16.0",
     "react-images": "^0.5.19",
-    "react-reveal": "^1.2.2",
+    "react-reveal-iframe": "^1.2.7",
     "react-slick": "^0.27.11",
     "reactstrap": "^8.5.1",
     "sass-loader": "^10.0.2",

--- a/src/Components/AnimateOnReveal.js
+++ b/src/Components/AnimateOnReveal.js
@@ -1,6 +1,6 @@
 import * as React from "react";
-import Zoom from "react-reveal/Zoom";
-import Fade from "react-reveal/Fade";
+import Zoom from "react-reveal-iframe/Zoom";
+import Fade from "react-reveal-iframe/Fade";
 
 function AnimateOnReveal({ animation, children }) {
   switch (animation) {


### PR DESCRIPTION
`react-reveal` is no longer maintained since two years. `react-reveal-iframe` has at least some small improvements to keep it alive.