### PR TITLE
Make transform also work for copy-webpack-plugin 6.1.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2929,19 +2929,20 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "copy-webpack-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.0.0.tgz",
-      "integrity": "sha512-tM6DhoJm8jvkHLjH62r5NHKSxmtyHYWOwWTkLWEZYHbxEH0Aele2pGRZ2HSDJb8Rdb/BcYWYFiJXTzHt377fPg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.1.0.tgz",
+      "integrity": "sha512-aWjIuLt1OVQxaDVffnt3bnGmLA8zGgAJaFwPA+a+QYVPh1vhIKjVfh3SbOFLV0kRPvGBITbw17n5CsmiBS4LQQ==",
       "requires": {
-        "cacache": "^15.0.3",
+        "cacache": "^15.0.5",
+        "fast-glob": "^3.2.4",
         "find-cache-dir": "^3.3.1",
         "glob-parent": "^5.1.1",
-        "globby": "^11.0.0",
+        "globby": "^11.0.1",
         "loader-utils": "^2.0.0",
         "normalize-path": "^3.0.0",
-        "p-limit": "^2.3.0",
-        "schema-utils": "^2.6.6",
-        "serialize-javascript": "^3.0.0",
+        "p-limit": "^3.0.2",
+        "schema-utils": "^2.7.1",
+        "serialize-javascript": "^4.0.0",
         "webpack-sources": "^1.4.3"
       },
       "dependencies": {
@@ -3008,12 +3009,30 @@
             "semver": "^6.0.0"
           }
         },
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
         "p-locate": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "requires": {
             "p-limit": "^2.2.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "path-exists": {
@@ -3033,14 +3052,6 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "serialize-javascript": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-          "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
-          "requires": {
-            "randombytes": "^2.1.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-loader": "^8.1.0",
     "clean-webpack-plugin": "^3.0.0",
     "content-security-policy-builder": "^2.1.0",
-    "copy-webpack-plugin": "6.0.0",
+    "copy-webpack-plugin": "^6.1.0",
     "core-js": "^3.6.5",
     "css-loader": "^4.3.0",
     "dateformat": "^3.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -166,14 +166,18 @@ function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
     new Webpackbar(),
     new CopyWebpackPlugin({
       patterns: [
-        { from: "../public", globOptions: { ignore: ignorePublicFiles } },
         {
-          from: "../public/_headers",
-          transform: (content) => {
-            const csp = builder({ directives: headersCsp });
-            return content
-              .toString()
-              .replace(/CSP-DIRECTIVES-PLACEHOLDER/g, csp);
+          from: "../public",
+          globOptions: { ignore: ignorePublicFiles },
+          transform: (content, absoluteFrom) => {
+            if (absoluteFrom.endsWith("/public/_headers")) {
+              const csp = builder({ directives: headersCsp });
+              return content
+                .toString()
+                .replace(/CSP-DIRECTIVES-PLACEHOLDER/g, csp);
+            }
+
+            return content;
           },
         },
         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -155,7 +155,7 @@ function generateEntry({ isPrerendering }) {
 }
 
 function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
-  const ignorePublicFiles = ["**/_headersCsp.json"];
+  const ignorePublicFiles = ["**/_headersCsp.json", "**/_headers"];
 
   const plugins = [
     new webpack.EnvironmentPlugin({
@@ -166,18 +166,14 @@ function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
     new Webpackbar(),
     new CopyWebpackPlugin({
       patterns: [
+        { from: "../public", globOptions: { ignore: ignorePublicFiles } },
         {
-          from: "../public",
-          globOptions: { ignore: ignorePublicFiles },
-          transform: (content, absoluteFrom) => {
-            if (absoluteFrom.endsWith("/public/_headers")) {
-              const csp = builder({ directives: headersCsp });
-              return content
-                .toString()
-                .replace(/CSP-DIRECTIVES-PLACEHOLDER/g, csp);
-            }
-
-            return content;
+          from: "../public/_headers",
+          transform: (content) => {
+            const csp = builder({ directives: headersCsp });
+            return content
+              .toString()
+              .replace(/CSP-DIRECTIVES-PLACEHOLDER/g, csp);
           },
         },
         {


### PR DESCRIPTION
Follow-up of https://github.com/Scrivito/scrivito_example_app_js/pull/339.

If multiple patterns reference similar or identical files (e.g. "../public" and "../public/_headers") it is not well defined, which pattern will be executed - the first or the last? ~To avoid this confusion now "../public" is copied, but only "public/_headers" is transformed.~ TO avoid this confusion copying `../public` does explicitly exclude `../public/_headers`.

copy-webpack-plugin 6.0.1 most likely broke because of https://github.com/webpack-contrib/copy-webpack-plugin/pull/484.