### PR TITLE
Replace resize with hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11201,6 +11201,14 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-resize-observer": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-6.1.0.tgz",
+      "integrity": "sha512-SiPcWHiIQ1CnHmb6PxbYtygqiZXR0U9dNkkbpX9VYnlstUwF8+QqpUTrzh13pjPwcjMVGR+QIC+nvF5ujfFNng==",
+      "requires": {
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "slick-carousel": "^1.6.0",
     "terser-webpack-plugin": "^4.2.3",
     "typescript": "^4.0.5",
+    "use-resize-observer": "^6.1.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
@@ -40,8 +40,12 @@ function InteractiveGoogleMap({ address, apiKey, zoom, children }) {
 }
 
 function StaticGoogleMap({ address, apiKey, zoom, children }) {
-  const { ref, width = null, height = null } = useResizeObserver();
-  const scaledMapSize = scaleMapSize(width, height);
+  const {
+    ref,
+    width: elementWidth = null,
+    height: elementHeight = null,
+  } = useResizeObserver();
+  const { width, height } = scaleMapSize(elementWidth, elementHeight);
 
   return (
     <div
@@ -50,8 +54,8 @@ function StaticGoogleMap({ address, apiKey, zoom, children }) {
       style={{
         background: "no-repeat center / cover",
         backgroundImage: `url(${getMapUrl({
-          width: scaledMapSize.width,
-          height: scaledMapSize.height,
+          width,
+          height,
           address,
           apiKey,
           zoom,
@@ -64,18 +68,14 @@ function StaticGoogleMap({ address, apiKey, zoom, children }) {
 }
 
 function scaleMapSize(width, height) {
-  if (!width || !height) {
+  if (!width || !height || width <= maxWidth) {
     return { width, height };
   }
 
-  if (width > maxWidth) {
-    const factor = height / width;
-    const adjustedHeight = Math.round(maxWidth * factor);
+  const factor = height / width;
+  const adjustedHeight = Math.round(maxWidth * factor);
 
-    return { width: maxWidth, height: adjustedHeight };
-  }
-
-  return { width, height };
+  return { width: maxWidth, height: adjustedHeight };
 }
 
 function getMapUrl({ width, height, address, apiKey, zoom }) {

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
@@ -64,17 +64,14 @@ function StaticGoogleMap({ address, apiKey, zoom, children }) {
 }
 
 function scaleMapSize(width, height) {
-  let newWidth = width;
-  let newHeight = height;
-
-  if (newWidth > maxWidth) {
-    newWidth = maxWidth;
-
+  if (width > maxWidth) {
     const factor = height / width;
-    newHeight = Math.round(maxWidth * factor);
+    const adjustedHeight = Math.round(maxWidth * factor);
+
+    return { width: maxWidth, height: adjustedHeight };
   }
 
-  return { width: newWidth, height: newHeight };
+  return { width, height };
 }
 
 function getMapUrl({ width, height, address, apiKey, zoom }) {

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
@@ -64,6 +64,10 @@ function StaticGoogleMap({ address, apiKey, zoom, children }) {
 }
 
 function scaleMapSize(width, height) {
+  if (!width || !height) {
+    return { width, height };
+  }
+
   if (width > maxWidth) {
     const factor = height / width;
     const adjustedHeight = Math.round(maxWidth * factor);


### PR DESCRIPTION
Follow-up to https://github.com/Scrivito/scrivito_example_app_js/pull/349#discussion_r515858241

https://www.npmjs.com/package/use-resize-observer#the-onresize-callback
> By the default the hook will trigger a re-render on all changes to the target element's width and / or height.

That's why we don't have to compare anymore an old and a new size. 