### PR TITLE
Bugfix: No longer crash SearchResultsComponent, if params.q is undefined

### DIFF
--- a/src/Objs/SearchResults/SearchResultsComponent.js
+++ b/src/Objs/SearchResults/SearchResultsComponent.js
@@ -87,7 +87,7 @@ class SearchResultsComponent extends React.Component {
   }
 
   query() {
-    return this.props.params.q.trim();
+    return this.props.params.q ? this.props.params.q.trim() : "";
   }
 }
 


### PR DESCRIPTION
The error can be observed, if one calls "npm run prerender".

Introduced with https://github.com/Scrivito/scrivito_example_app_js/pull/352.