### PR TITLE
Allow to pass arguments to puppeteer

### DIFF
--- a/prerender/storePrerenderedContent.js
+++ b/prerender/storePrerenderedContent.js
@@ -48,7 +48,9 @@ async function storePrerenderedContent() {
 
   try {
     log("🖥️️  Starting browser...");
-    const browser = await puppeteer.launch();
+    const browser = await puppeteer.launch({
+      args: (process.env.PUPPETEER_ARGS || "").split(" "),
+    });
     log("🖥️️  Browser started");
 
     try {


### PR DESCRIPTION
During our migration to AWS Amplify we had the issue that AWS builds with the root user. The is not possible without the flag `--no-sandbox` (I know it bad :/ ). So I give the ability to pass arguments to Puppeteer. That could be useful for other issues.