### PR TITLE
[prerender] Disable sandbox in AWS lambda environment.

### DIFF
--- a/prerender/storePrerenderedContent.js
+++ b/prerender/storePrerenderedContent.js
@@ -48,7 +48,11 @@ async function storePrerenderedContent() {
 
   try {
     log("🖥️️  Starting browser...");
-    const browser = await puppeteer.launch();
+    const browser = await puppeteer.launch({
+      args: process.env.AWS_EXECUTION_ENV
+        ? ["--no-sandbox", "--disable-setuid-sandbox"]
+        : [],
+    });
     log("🖥️️  Browser started");
 
     try {


### PR DESCRIPTION
Otherwise prerendering might not work.

See [1] for details about env "AWS_EXECUTION_ENV".

[1] https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html

Motivated by https://github.com/Scrivito/scrivito_example_app_js/pull/369.

@cbou: Can you confirm, that prerendering works on "AWS Amplify" with this patch?