### PR TITLE
Use configureObjClassForContentType

### DIFF
--- a/src/Objs/_defaultPageAttributes.js
+++ b/src/Objs/_defaultPageAttributes.js
@@ -1,9 +1,6 @@
 const defaultPageAttributes = {
   body: ["widgetlist", { only: "SectionWidget" }],
-  navigationBackgroundImage: [
-    "reference",
-    { only: ["Image", "Video", "Download"] },
-  ],
+  navigationBackgroundImage: ["reference", { only: ["Image", "Video"] }],
   navigationBackgroundImageGradient: ["enum", { values: ["yes", "no"] }],
   navigationHeight: [
     "enum",

--- a/src/Widgets/VideoWidget/VideoWidgetClass.js
+++ b/src/Widgets/VideoWidget/VideoWidgetClass.js
@@ -2,7 +2,7 @@ import * as Scrivito from "scrivito";
 
 const VideoWidget = Scrivito.provideWidgetClass("VideoWidget", {
   attributes: {
-    source: ["reference", { only: ["Video", "Download"] }],
+    source: ["reference", { only: ["Video"] }],
     poster: ["reference", { only: ["Image"] }],
   },
 });

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,5 @@
 import "./scrivito";
 import "./history";
+import "./objClassForContentType";
 import "./scrivitoContentBrowser";
 import "./windowScrivito";

--- a/src/config/objClassForContentType.js
+++ b/src/config/objClassForContentType.js
@@ -1,0 +1,7 @@
+import * as Scrivito from "scrivito";
+
+Scrivito.configureObjClassForContentType({
+  "image/*": "Image", // Factory default
+  "video/*": "Video",
+  "*/*": "Download", // Factory default
+});

--- a/src/config/objClassForContentType.js
+++ b/src/config/objClassForContentType.js
@@ -1,7 +1,7 @@
 import * as Scrivito from "scrivito";
 
 Scrivito.configureObjClassForContentType({
-  "image/*": "Image", // Factory default
+  "image/*": "Image",
   "video/*": "Video",
-  "*/*": "Download", // Factory default
+  "*/*": "Download",
 });

--- a/src/config/scrivito.js
+++ b/src/config/scrivito.js
@@ -15,9 +15,3 @@ if (process.env.SCRIVITO_PRERENDER) {
 }
 
 Scrivito.configure(config);
-
-Scrivito.configureObjClassForContentType({
-  "image/*": "Image", // Factory default
-  "video/*": "Video",
-  "*/*": "Download", // Factory default
-});

--- a/src/config/scrivito.js
+++ b/src/config/scrivito.js
@@ -15,3 +15,9 @@ if (process.env.SCRIVITO_PRERENDER) {
 }
 
 Scrivito.configure(config);
+
+Scrivito.configureObjClassForContentType({
+  "image/*": "Image", // Factory default
+  "video/*": "Video",
+  "*/*": "Download", // Factory default
+});


### PR DESCRIPTION
IF you upload a video to the Content Browser it now automatically becomes a "Video" obj class. Previously it was a generic "Download" obj class. See https://www.scrivito.com/js-sdk/configureObjClassForContentType for more details.

Because of that, we can restrict `VideoWidget` and `navigationBackgroundImage` more to `Video` or `Image`/`Video`.