### PR TITLE
Bugfix: Only use background priority during prerender.

### DIFF
--- a/src/config/history.js
+++ b/src/config/history.js
@@ -2,8 +2,10 @@ import { createBrowserHistory } from "history";
 import { useHistory as scrivitoUseHistory } from "scrivito";
 import { scrollToFragment } from "scroll-to-fragment";
 
-const history = createBrowserHistory();
+export function configureHistory() {
+  const history = createBrowserHistory();
 
-scrivitoUseHistory(history);
+  scrivitoUseHistory(history);
 
-scrollToFragment({ history });
+  scrollToFragment({ history });
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,5 +1,13 @@
-import "./scrivito";
-import "./history";
-import "./objClassForContentType";
-import "./scrivitoContentBrowser";
-import "./windowScrivito";
+import { configureScrivito } from "./scrivito";
+import { configureHistory } from "./history";
+import { configureObjClassForContentType } from "./objClassForContentType";
+import { configureScrivitoContentBrowser } from "./scrivitoContentBrowser";
+import { configureWindowScrivito } from "./windowScrivito";
+
+export function configure() {
+  configureScrivito();
+  configureHistory();
+  configureScrivitoContentBrowser();
+  configureObjClassForContentType();
+  configureWindowScrivito();
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,8 +4,8 @@ import { configureObjClassForContentType } from "./objClassForContentType";
 import { configureScrivitoContentBrowser } from "./scrivitoContentBrowser";
 import { configureWindowScrivito } from "./windowScrivito";
 
-export function configure() {
-  configureScrivito();
+export function configure(options) {
+  configureScrivito(options);
   configureHistory();
   configureScrivitoContentBrowser();
   configureObjClassForContentType();

--- a/src/config/objClassForContentType.js
+++ b/src/config/objClassForContentType.js
@@ -1,7 +1,9 @@
 import * as Scrivito from "scrivito";
 
-Scrivito.configureObjClassForContentType({
-  "image/*": "Image",
-  "video/*": "Video",
-  "*/*": "Download",
-});
+export function configureObjClassForContentType() {
+  Scrivito.configureObjClassForContentType({
+    "image/*": "Image",
+    "video/*": "Video",
+    "*/*": "Download",
+  });
+}

--- a/src/config/scrivito.js
+++ b/src/config/scrivito.js
@@ -11,9 +11,6 @@ if (process.env.SCRIVITO_ENDPOINT) {
 }
 
 export function configureScrivito(options) {
-  const scrivitoConfig = { ...config };
-  if (options?.useScrivitoBackgroundPriority) {
-    scrivitoConfig.priority = "background";
-  }
-  Scrivito.configure(scrivitoConfig);
+  const priority = options?.priority;
+  Scrivito.configure(priority ? { ...config, priority } : config);
 }

--- a/src/config/scrivito.js
+++ b/src/config/scrivito.js
@@ -10,10 +10,10 @@ if (process.env.SCRIVITO_ENDPOINT) {
   config.endpoint = process.env.SCRIVITO_ENDPOINT;
 }
 
-if (process.env.SCRIVITO_PRERENDER) {
-  config.priority = "background";
-}
-
-export function configureScrivito() {
-  Scrivito.configure(config);
+export function configureScrivito(options) {
+  const scrivitoConfig = { ...config };
+  if (options?.useScrivitoBackgroundPriority) {
+    scrivitoConfig.priority = "background";
+  }
+  Scrivito.configure(scrivitoConfig);
 }

--- a/src/config/scrivito.js
+++ b/src/config/scrivito.js
@@ -14,4 +14,6 @@ if (process.env.SCRIVITO_PRERENDER) {
   config.priority = "background";
 }
 
-Scrivito.configure(config);
+export function configureScrivito() {
+  Scrivito.configure(config);
+}

--- a/src/config/scrivitoContentBrowser.js
+++ b/src/config/scrivitoContentBrowser.js
@@ -1,21 +1,23 @@
 import * as Scrivito from "scrivito";
 
-Scrivito.configureContentBrowser({
-  filters: ({ _validObjClasses }) => {
-    if (_validObjClasses) {
-      switch (_validObjClasses.length) {
-        case 0:
-          return defaultFilters();
-        case 1:
-          return filterForObjClass(_validObjClasses[0]);
-        default:
-          return filtersForObjClasses(_validObjClasses);
+export function configureScrivitoContentBrowser() {
+  Scrivito.configureContentBrowser({
+    filters: ({ _validObjClasses }) => {
+      if (_validObjClasses) {
+        switch (_validObjClasses.length) {
+          case 0:
+            return defaultFilters();
+          case 1:
+            return filterForObjClass(_validObjClasses[0]);
+          default:
+            return filtersForObjClasses(_validObjClasses);
+        }
       }
-    }
 
-    return defaultFilters();
-  },
-});
+      return defaultFilters();
+    },
+  });
+}
 
 function filterForObjClass(objClass) {
   return {

--- a/src/config/windowScrivito.js
+++ b/src/config/windowScrivito.js
@@ -1,4 +1,6 @@
 import * as Scrivito from "scrivito";
 
-// set Scrivito as a global to allow easier debugging in the javascript console.
-window.Scrivito = Scrivito;
+export function configureWindowScrivito() {
+  // set Scrivito as a global to allow easier debugging in the javascript console.
+  window.Scrivito = Scrivito;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,10 @@ import * as Scrivito from "scrivito";
 import "./Objs";
 import "./Widgets";
 import App from "./App";
-import "./config";
+import { configure } from "./config";
 import "./assets/stylesheets/index.scss";
+
+configure();
 
 if (window.preloadDump) {
   Scrivito.preload(window.preloadDump).then(({ dumpLoaded }) => {

--- a/src/prerender_content.js
+++ b/src/prerender_content.js
@@ -3,9 +3,11 @@ import "scrivito";
 import filesize from "filesize";
 import "./Objs";
 import "./Widgets";
-import "./config";
+import { configure } from "./config";
 import prerenderObjs from "./prerenderContent/prerenderObjs";
 import prerenderSitemap from "./prerenderContent/prerenderSitemap";
+
+configure();
 
 const PRERENDER_OBJ_CLASSES_BLACKLIST = [
   "Download",

--- a/src/prerender_content.js
+++ b/src/prerender_content.js
@@ -7,7 +7,7 @@ import { configure } from "./config";
 import prerenderObjs from "./prerenderContent/prerenderObjs";
 import prerenderSitemap from "./prerenderContent/prerenderSitemap";
 
-configure();
+configure({ useScrivitoBackgroundPriority: true });
 
 const PRERENDER_OBJ_CLASSES_BLACKLIST = [
   "Download",

--- a/src/prerender_content.js
+++ b/src/prerender_content.js
@@ -7,7 +7,7 @@ import { configure } from "./config";
 import prerenderObjs from "./prerenderContent/prerenderObjs";
 import prerenderSitemap from "./prerenderContent/prerenderSitemap";
 
-configure({ useScrivitoBackgroundPriority: true });
+configure({ priority: "background" });
 
 const PRERENDER_OBJ_CLASSES_BLACKLIST = [
   "Download",

--- a/src/scrivito_extensions.js
+++ b/src/scrivito_extensions.js
@@ -1,5 +1,7 @@
 import "./Objs";
 import "./Widgets";
-import "./config";
+import { configure } from "./config";
 import "./Components/ScrivitoExtensions";
 import "./assets/stylesheets/index.scss";
+
+configure();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,7 +153,6 @@ function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
       NODE_ENV: isProduction ? "production" : "development",
       SCRIVITO_ENDPOINT: "",
       SCRIVITO_ORIGIN: scrivitoOrigin,
-      SCRIVITO_PRERENDER: "",
       SCRIVITO_TENANT: "",
     }),
     new Webpackbar(),


### PR DESCRIPTION
The `priority` allows to differentiate between `foreground` and `background`. If set to `background` a different rate limit is used than with `foreground`. This should ensure, that prerendering tasks do not "eat" rate of visitors. See https://www.scrivito.com/js-sdk/configure for more details.

For this to work visitors must _not_ use `background` for the `priority`. Since https://github.com/Scrivito/scrivito_example_app_js/pull/366 that was sadly the case, if you prerendered the site.

This PR fixes the issue by only setting `background` during actual prerender (`src/prerender_content.js`) and _not_ during "regular" visits (`src/index.js`).

Diff best reviewed without whitespace changes.