### PR TITLE
Make configureScrivito side-effect free

### DIFF
--- a/src/config/scrivito.js
+++ b/src/config/scrivito.js
@@ -1,16 +1,16 @@
 import * as Scrivito from "scrivito";
 
-const config = { tenant: process.env.SCRIVITO_TENANT, adoptUi: true };
-
-if (process.env.SCRIVITO_ORIGIN) {
-  config.origin = process.env.SCRIVITO_ORIGIN;
-}
-
-if (process.env.SCRIVITO_ENDPOINT) {
-  config.endpoint = process.env.SCRIVITO_ENDPOINT;
-}
-
 export function configureScrivito(options) {
+  const config = { tenant: process.env.SCRIVITO_TENANT, adoptUi: true };
+
+  if (process.env.SCRIVITO_ORIGIN) {
+    config.origin = process.env.SCRIVITO_ORIGIN;
+  }
+
+  if (process.env.SCRIVITO_ENDPOINT) {
+    config.endpoint = process.env.SCRIVITO_ENDPOINT;
+  }
+
   const priority = options?.priority;
   Scrivito.configure(priority ? { ...config, priority } : config);
 }

--- a/src/config/scrivito.js
+++ b/src/config/scrivito.js
@@ -11,6 +11,9 @@ export function configureScrivito(options) {
     config.endpoint = process.env.SCRIVITO_ENDPOINT;
   }
 
-  const priority = options?.priority;
-  Scrivito.configure(priority ? { ...config, priority } : config);
+  if (options?.priority) {
+    config.priority = options.priority;
+  }
+
+  Scrivito.configure(config);
 }


### PR DESCRIPTION
This is general best practice, but also handy when running the code under Node.js in conjunction with `dotenv`.