### PR TITLE
Better SSR support

### DIFF
--- a/src/Components/CookieConsentContext.js
+++ b/src/Components/CookieConsentContext.js
@@ -3,9 +3,11 @@ import * as React from "react";
 const CookieConsentContext = React.createContext({});
 
 export function CookieConsentProvider(props) {
-  const [cookieConsentChoice, setCookieConsentChoice] = React.useState(() =>
-    getCookieConsent()
+  const [cookieConsentChoice, setCookieConsentChoice] = React.useState(
+    "undecided"
   );
+
+  React.useEffect(() => setCookieConsentChoice(getCookieConsent()), []);
 
   function updateCookieConsent(consent) {
     localStorage.setItem("CookieConsent", consent);

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,10 +6,10 @@ import { configureWindowScrivito } from "./windowScrivito";
 
 export function configure(options) {
   configureScrivito(options);
-  configureScrivitoContentBrowser();
   configureObjClassForContentType();
 
   if (typeof window !== "undefined") {
+    configureScrivitoContentBrowser();
     configureHistory();
     configureWindowScrivito();
   }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,8 +6,11 @@ import { configureWindowScrivito } from "./windowScrivito";
 
 export function configure(options) {
   configureScrivito(options);
-  configureHistory();
   configureScrivitoContentBrowser();
   configureObjClassForContentType();
-  configureWindowScrivito();
+
+  if (typeof window !== "undefined") {
+    configureHistory();
+    configureWindowScrivito();
+  }
 }

--- a/src/utils/fullScreenWidthPixels.js
+++ b/src/utils/fullScreenWidthPixels.js
@@ -1,5 +1,9 @@
 import devicePixelRatio from "./devicePixelRatio";
 
+/**
+ * Based on (and thus optimized for) the Lighthouse mobile emulation.
+ * See https://github.com/GoogleChrome/lighthouse/blob/777bf1147fd0f6aca16ffefde1350bf6297476d4/lighthouse-core/config/constants.js#L58-L63.
+ * */
 const SSR_FALLBACK_WIDTH_PX = 945;
 
 function fullScreenWidthPixels() {

--- a/src/utils/fullScreenWidthPixels.js
+++ b/src/utils/fullScreenWidthPixels.js
@@ -1,6 +1,12 @@
 import devicePixelRatio from "./devicePixelRatio";
 
+const SSR_FALLBACK_WIDTH_PX = 945;
+
 function fullScreenWidthPixels() {
+  if (typeof window === "undefined") {
+    return SSR_FALLBACK_WIDTH_PX;
+  }
+
   const screenWidth = window.screen.width;
 
   return screenWidth * devicePixelRatio();


### PR DESCRIPTION
Three smaller changes to be able to render server side, even without a `window`.

**Note**
I also considered moving `configureScrivitoContentBrowser()` and `configureObjClassForContentType()` to the window specific block. These are not strictly needed in a window-less (and thus no-editing) environment.