### PR TITLE
Prerendering: Fix <LS> and <PS> line terminators for IE11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ configure();
 
 if (window.preloadDump) {
   Scrivito.preload(window.preloadDump).then(({ dumpLoaded }) => {
+    delete window.preloadDump;
     dumpLoaded ? hydrateApp() : renderApp();
   });
 } else {

--- a/src/prerenderContent/generatePreloadDump.js
+++ b/src/prerenderContent/generatePreloadDump.js
@@ -1,3 +1,13 @@
 export default function generatePreloadDump(preloadDump) {
-  return `window.preloadDump = ${JSON.stringify(preloadDump)};`;
+  return `window.preloadDump = ${stringLiteral(preloadDump)};`;
+}
+
+/**
+ * JSON may contain line separators, which are invalid in string literals in older browsers.
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#issue_with_plain_json.stringify_for_use_as_javascript
+ * */
+function stringLiteral(string) {
+  return JSON.stringify(string)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }


### PR DESCRIPTION
Fixes a bug where a dump containing one of the line terminators `<LS>` and `<PS>` (see https://262.ecma-international.org/5.1/#sec-7.3) would lead to invalid code on older browsers (👋 IE11).

As an additional optimization, we allow to garbage collect the dump string after use.