### PR TITLE
Use npm 7 on Travis and Netlify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 language: node_js
 node_js: 10
 sudo: false
+before_install:
+  - dpkg --compare-versions `npm -v` ge 7.10 || npm i -g npm@^7.10
+  - npm --version
 cache:
   directories:
     - "node_modules"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,6 @@
 [build]
   command = "npm run build"
   publish = "build"
+
+[build.environment]
+  NPM_VERSION = "7.10"


### PR DESCRIPTION
I already switch locally to npm 7 in [1]. But I did not yet switch to npm 7 on Travis and Netlify. Now is the time.

Without this change subtle failures could emerge. E.g. an update of webpack locally ran fine, but failed on Netlify.

This can be removed, as soon as the node version installs npm v7 by default. According to [2] this is node version 15 or newer.

Inspired by [3] and [4].

Please note, that you'll need to clear your Netlify cache. Otherwise your build will fail due to wrong npm package cache.

[1] https://github.com/Scrivito/scrivito_example_app_js/pull/375
[2] https://nodejs.org/en/download/releases/
[3] travis-ci/travis-ci#4653 (comment)
[4] https://docs.netlify.com/configure-builds/manage-dependencies/#npm