### PR TITLE
Fix #382

### DIFF
--- a/src/assets/stylesheets/_blog.scss
+++ b/src/assets/stylesheets/_blog.scss
@@ -52,6 +52,8 @@
         }
 
         &--panel {
+          background: #fff;
+
           &:before {
             border-left-width: 0;
             border-right-width: 15px;
@@ -95,6 +97,7 @@
         float: left;
         border: 1px solid #eee;
         position: relative;
+        background: #fff;
 
         &:before {
           position: absolute;

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -615,6 +615,36 @@ $easing: cubic-bezier(0.7, 0, 0, 0.7);
   }
 }
 
+.bg-dark-image,
+.bg-brand-primary,
+.bg-brand-secondary,
+.bg-grey,
+.bg-greydark,
+.bg-greymiddle {
+  .blog-timeline--panel {
+    p,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .h1,
+    .h2,
+    .h3,
+    .h4,
+    .h5,
+    .h6,
+    .card.card-theme,
+    .edit-mode-link {
+      color: $theme-grey!important;
+    }
+  }
+}
+
+
+
+
 footer {
   .bg-dark-image,
   .bg-brand-primary,
@@ -755,6 +785,7 @@ section.navbar-fixed {
   .h6 {
     color: $theme-greydark !important;
   }
+  .fa,
   p {
     color: $theme-greymiddle !important;
   }


### PR DESCRIPTION
Regarding `Links in Blog Overview Widgets don't adjust color according to background-image #382 `

I found two issues. Blog panels are now always with white bachground and grey text. 
Secound issue was when card boxes was on dark background.. fa icons inside was white.. new grey.
![bg-issue1](https://user-images.githubusercontent.com/710311/116052503-f7962d00-a679-11eb-8416-ba9726c11f88.png)

![bg-issue2](https://user-images.githubusercontent.com/710311/116052526-fbc24a80-a679-11eb-9e70-4c4561d0bfcc.png)
