### PR TITLE
Simplify webpack config by separating development and production

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "zip-webpack-plugin": "^4.0.1"
   },
   "scripts": {
-    "build": "webpack --env production",
+    "build": "webpack --config webpack.config.production.js",
     "prerender": "SCRIVITO_PRERENDER=true npm run build && node prerender/storePrerenderedContent.js",
     "start": "webpack serve",
     "eslint": "eslint --max-warnings 0 src/ prerender/",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,8 +14,6 @@ const headersCsp = require("./public/_headersCsp.json");
 // load ".env"
 dotenv.config();
 
-const isPrerendering = process.env.SCRIVITO_PRERENDER;
-
 let scrivitoOrigin = "";
 if (process.env.CONTEXT === "production") {
   scrivitoOrigin = process.env.URL;
@@ -46,7 +44,11 @@ function webpackConfig(env = {}) {
   return {
     mode: "development",
     context: path.join(__dirname, "src"),
-    entry: generateEntry(),
+    entry: {
+      index: "./index.js",
+      tracking: "./tracking.js",
+      scrivito_extensions: "./scrivito_extensions.js",
+    },
     target: "web",
     module: {
       rules: [
@@ -130,22 +132,10 @@ function webpackConfig(env = {}) {
   };
 }
 
-function generateEntry() {
-  const entry = {
-    index: "./index.js",
-    tracking: "./tracking.js",
-    scrivito_extensions: "./scrivito_extensions.js",
-  };
-  if (isPrerendering) {
-    entry.prerender_content = "./prerender_content.js";
-  }
-  return entry;
-}
-
 function generatePlugins(nodeEnv) {
   const ignorePublicFiles = ["**/_headersCsp.json", "**/_headers"];
 
-  const plugins = [
+  return [
     new webpack.EnvironmentPlugin({
       NODE_ENV: nodeEnv,
       SCRIVITO_ENDPOINT: "",
@@ -186,18 +176,6 @@ function generatePlugins(nodeEnv) {
 
     new webpack.SourceMapDevToolPlugin({}),
   ];
-
-  if (isPrerendering) {
-    plugins.push(
-      new HtmlWebpackPlugin({
-        filename: "_prerender_content.html",
-        template: "_prerender_content.html",
-        chunks: ["prerender_content"],
-      })
-    );
-  }
-
-  return plugins;
 }
 
 function devServerCspHeader() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,13 +4,11 @@ const path = require("path");
 const process = require("process");
 const webpack = require("webpack");
 const lodash = require("lodash");
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const { WebpackManifestPlugin } = require("webpack-manifest-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const Webpackbar = require("webpackbar");
-const ZipPlugin = require("zip-webpack-plugin");
 const headersCsp = require("./public/_headersCsp.json");
 
 // load ".env"
@@ -47,10 +45,10 @@ function webpackConfig(env = {}) {
   }
 
   return {
-    mode: isProduction ? "production" : "development",
+    mode: "development",
     context: path.join(__dirname, "src"),
     entry: generateEntry({ isPrerendering }),
-    target: isProduction ? ["web", "es5"] : "web",
+    target: "web",
     module: {
       rules: [
         {
@@ -185,6 +183,9 @@ function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
       chunks: ["scrivito_extensions"],
     }),
     new webpack.optimize.ModuleConcatenationPlugin(),
+    new WebpackManifestPlugin({ fileName: "asset-manifest.json" }),
+
+    new webpack.SourceMapDevToolPlugin({}),
   ];
 
   if (isPrerendering) {
@@ -195,25 +196,6 @@ function generatePlugins({ isProduction, isPrerendering, scrivitoOrigin }) {
         chunks: ["prerender_content"],
       })
     );
-  }
-
-  if (!isProduction || isPrerendering) {
-    plugins.push(
-      new WebpackManifestPlugin({ fileName: "asset-manifest.json" })
-    );
-  }
-
-  if (isProduction) {
-    plugins.unshift(new CleanWebpackPlugin());
-    plugins.push(
-      new ZipPlugin({
-        filename: "build.zip",
-        path: "../",
-        pathPrefix: "build/",
-      })
-    );
-  } else {
-    plugins.push(new webpack.SourceMapDevToolPlugin({}));
   }
 
   return plugins;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,13 +14,6 @@ const headersCsp = require("./public/_headersCsp.json");
 // load ".env"
 dotenv.config();
 
-let scrivitoOrigin = "";
-if (process.env.CONTEXT === "production") {
-  scrivitoOrigin = process.env.URL;
-} else if (process.env.DEPLOY_PRIME_URL) {
-  scrivitoOrigin = process.env.DEPLOY_PRIME_URL;
-}
-
 // Extend headersCsp with custom endpoint URL
 const endpoint = process.env.SCRIVITO_ENDPOINT;
 if (endpoint) {
@@ -39,6 +32,14 @@ function webpackConfig(env = {}) {
       ' Check if the ".env" file with a proper SCRIVITO_TENANT is set.' +
       ' See ".env.example" for an example.'
     );
+  }
+
+  let scrivitoOrigin = "";
+  // Netlify build environment, see https://docs.netlify.com/configure-builds/environment-variables/
+  if (process.env.CONTEXT === "production") {
+    scrivitoOrigin = process.env.URL;
+  } else if (process.env.DEPLOY_PRIME_URL) {
+    scrivitoOrigin = process.env.DEPLOY_PRIME_URL;
   }
 
   return {

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -8,15 +8,20 @@ const devWebpackConfig = require("./webpack.config");
 const isPrerendering = process.env.SCRIVITO_PRERENDER;
 
 function webpackConfig(env = {}) {
-  const devConfig = devWebpackConfig({ ...env, production: true });
+  const {
+    mode: _devMode,
+    target: _devTarget,
+    plugins: devPlugins,
+    ...sharedConfig
+  } = devWebpackConfig({ ...env, production: true });
 
   return {
-    ...devConfig,
+    ...sharedConfig,
     mode: "production",
     target: ["web", "es5"],
     plugins: [
       new CleanWebpackPlugin(),
-      ...filterDevPlugins(devConfig.plugins),
+      ...filterDevPlugins(devPlugins),
       new ZipPlugin({
         filename: "build.zip",
         path: "../",

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -1,8 +1,41 @@
-const baseWebpackConfig = require("./webpack.config");
+const webpack = require("webpack");
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const { WebpackManifestPlugin } = require("webpack-manifest-plugin");
+const ZipPlugin = require("zip-webpack-plugin");
+
+const devWebpackConfig = require("./webpack.config");
+
+const isPrerendering = process.env.SCRIVITO_PRERENDER;
 
 function webpackConfig(env = {}) {
-  const config = baseWebpackConfig({ ...env, production: true });
-  return config;
+  const devConfig = devWebpackConfig({ ...env, production: true });
+
+  return {
+    ...devConfig,
+    mode: "production",
+    target: ["web", "es5"],
+    plugins: [
+      new CleanWebpackPlugin(),
+      ...filterDevPlugins(devConfig.plugins),
+      new ZipPlugin({
+        filename: "build.zip",
+        path: "../",
+        pathPrefix: "build/",
+      }),
+    ],
+  };
+}
+
+function filterDevPlugins(plugins) {
+  return plugins.filter((plugin) => {
+    if (plugin instanceof webpack.SourceMapDevToolPlugin) {
+      return false;
+    }
+    if (plugin instanceof WebpackManifestPlugin && !isPrerendering) {
+      return false;
+    }
+    return true;
+  });
 }
 
 module.exports = webpackConfig;

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -11,6 +11,7 @@ function webpackConfig(env = {}) {
   const {
     mode: _devMode,
     target: _devTarget,
+    devServer: _devServer,
     plugins: devPlugins,
     ...sharedConfig
   } = devWebpackConfig({ ...env, production: true });

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -1,0 +1,8 @@
+const baseWebpackConfig = require("./webpack.config");
+
+function webpackConfig(env = {}) {
+  const config = baseWebpackConfig({ ...env, production: true });
+  return config;
+}
+
+module.exports = webpackConfig;


### PR DESCRIPTION
We now have:

* `webpack.config.js` for the development setup. It is agnostic of a production setup. To keep the EnvironmentPlugin use DRY, it still looks at `env.production` once, but this is an official webpack env. Alternative ideas welcome.
* `webpack.config.production.js` for production. It relies on the dev setup to provide sensible defaults. The production settings are then added to the default, and filtered where needed.