### PR TITLE
Added "Title for editors" to Homepage obj class.

### DIFF
--- a/src/Objs/Homepage/HomepageEditingConfig.js
+++ b/src/Objs/Homepage/HomepageEditingConfig.js
@@ -20,6 +20,9 @@ Scrivito.provideEditingConfig("Homepage", {
   attributes: {
     ...defaultPageEditingConfigAttributes,
     ...metadataEditingConfigAttributes,
+    contentTitle: {
+      title: "Title for editors",
+    },
     logoDark: {
       title: "Dark logo",
       description: "Used with light backgrounds",
@@ -72,7 +75,7 @@ Scrivito.provideEditingConfig("Homepage", {
         'If you set this link, a cookie consent box will be shown on every page. The link should point to your privacy policy. The link title defaults to "Learn more »".',
     },
   },
-  properties: [...defaultPageProperties, "showAsLandingPage"],
+  properties: ["contentTitle", ...defaultPageProperties, "showAsLandingPage"],
   propertiesGroups: [
     {
       title: "Site settings",

--- a/src/Objs/Homepage/HomepageObjClass.js
+++ b/src/Objs/Homepage/HomepageObjClass.js
@@ -7,6 +7,7 @@ const Homepage = Scrivito.provideObjClass("Homepage", {
     ...defaultPageAttributes,
     showAsLandingPage: ["enum", { values: ["yes", "no"] }],
     cookieConsentLink: "link",
+    contentTitle: "string",
     childOrder: "referencelist",
     footer: ["widgetlist", { only: "SectionWidget" }],
     logoDark: ["reference", { only: ["Image"] }],


### PR DESCRIPTION
Since [version 1.22.0](https://www.scrivito.com/scrivito-js-1-22-0-released-featuring-language-aware-search-bc64a95b4cb84800) Scrivito provides a way for editors to set a title only for editors. To use it, one has to provide a `contentTitle` attribute of type `string`.

This PR adds `contentTitle` attribute to ~every non-binary obj class~ _Homepage_.

<img width="559" alt="content title in action v3" src="https://user-images.githubusercontent.com/86275/117448471-15e40e80-af3f-11eb-9dc9-7bd4b2ddd478.png">
