### PR TITLE
Make use of the page defined language as html lang attribute.

### DIFF
--- a/src/Components/CurrentPageMetadata.js
+++ b/src/Components/CurrentPageMetadata.js
@@ -5,7 +5,7 @@ import getMetadata from "../utils/getMetadata";
 import favicon from "../assets/images/favicon.png";
 
 const CurrentPageMetadata = Scrivito.connect(() => {
-  const htmlAttributes = { lang: "en" };
+  let lang = "en";
   let title = "";
   let meta = [];
   const links = [
@@ -18,10 +18,13 @@ const CurrentPageMetadata = Scrivito.connect(() => {
 
   const page = Scrivito.currentPage();
   if (page) {
+    lang = page.language() || "en";
     title = page.get("title") || "";
     meta = getMetadata(page);
     links.push({ rel: "canonical", href: Scrivito.urlFor(page) });
   }
+
+  const htmlAttributes = { lang };
 
   return (
     <Helmet


### PR DESCRIPTION
Falls back to "en" if no language is provided.