### PR TITLE
Don't apply module concatenation twice

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -155,7 +155,6 @@ function webpackConfig(env = {}) {
         template: "_scrivito_extensions.html",
         chunks: ["scrivito_extensions"],
       }),
-      new webpack.optimize.ModuleConcatenationPlugin(),
       new webpack.SourceMapDevToolPlugin({}),
       new WebpackManifestPlugin({ fileName: "asset-manifest.json" }),
     ],


### PR DESCRIPTION
Fixes #399 (webpack >=v5.24.1 compatibility)
according to https://github.com/webpack/webpack.js.org/issues/4837#issuecomment-816754861