### PR TITLE
Make `contentTitle` for homepages more self-explanatory

### DIFF
--- a/src/Objs/Homepage/HomepageEditingConfig.js
+++ b/src/Objs/Homepage/HomepageEditingConfig.js
@@ -21,7 +21,7 @@ Scrivito.provideEditingConfig("Homepage", {
     ...defaultPageEditingConfigAttributes,
     ...metadataEditingConfigAttributes,
     contentTitle: {
-      title: "Title for editors",
+      title: "Site name",
     },
     logoDark: {
       title: "Dark logo",
@@ -75,11 +75,12 @@ Scrivito.provideEditingConfig("Homepage", {
         'If you set this link, a cookie consent box will be shown on every page. The link should point to your privacy policy. The link title defaults to "Learn more »".',
     },
   },
-  properties: ["contentTitle", ...defaultPageProperties, "showAsLandingPage"],
+  properties: [...defaultPageProperties, "showAsLandingPage"],
   propertiesGroups: [
     {
       title: "Site settings",
       properties: [
+        "contentTitle",
         "logoDark",
         "logoWhite",
         "dividerLogo",


### PR DESCRIPTION
* Move to the top of the "Site settings" tab
* Improve the label according to an internal discussion

Follow-up to https://github.com/Scrivito/scrivito_example_app_js/pull/394#pullrequestreview-654382514