### PR TITLE
Fix refactoring oversight in EnvironmentPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,7 +118,7 @@ function webpackConfig(env = {}) {
     },
     plugins: [
       new webpack.EnvironmentPlugin({
-        NODE_ENV: env.isProduction ? "production" : "development",
+        NODE_ENV: env.production ? "production" : "development",
         SCRIVITO_ENDPOINT: "",
         SCRIVITO_ORIGIN: scrivitoOrigin,
         SCRIVITO_TENANT: "",


### PR DESCRIPTION
Introduced in 497c14646d1bc53db41c57d9103a175952b52641

`env` actually looks like `{ WEBPACK_BUNDLE: true, WEBPACK_BUILD: true, production: true }`