### PR TITLE
Improved custom widget components

### DIFF
--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -18,6 +18,8 @@ class ColumnsEditorTab extends React.Component {
   }
 
   render() {
+    const readOnly = !Scrivito.canWrite();
+
     return (
       <div className="scrivito_detail_content">
         <Alignment widget={this.props.widget} />
@@ -114,6 +116,7 @@ class ColumnsEditorTab extends React.Component {
           <GridLayoutEditor
             currentGrid={this.state.currentGrid}
             adjustGrid={this.adjustGrid}
+            readOnly={readOnly}
           />
         </div>
       </div>
@@ -261,151 +264,149 @@ const Alignment = Scrivito.connect(({ widget }) => {
   }
 });
 
-const GridLayoutEditor = Scrivito.connect(
-  class GridLayoutEditor extends React.Component {
-    constructor(props) {
-      super(props);
+class GridLayoutEditor extends React.Component {
+  constructor(props) {
+    super(props);
 
-      this.state = {
-        draggableGrid: 0,
-      };
+    this.state = {
+      draggableGrid: 0,
+    };
 
-      this.gridRulerRef = React.createRef();
+    this.gridRulerRef = React.createRef();
 
-      this.adjustNumberOfColumns = this.adjustNumberOfColumns.bind(this);
-      this.handleResize = this.handleResize.bind(this);
-      this.onDragStop = this.onDragStop.bind(this);
-    }
+    this.adjustNumberOfColumns = this.adjustNumberOfColumns.bind(this);
+    this.handleResize = this.handleResize.bind(this);
+    this.onDragStop = this.onDragStop.bind(this);
+  }
 
-    componentDidMount() {
-      this.handleResize();
-      window.addEventListener("resize", this.handleResize);
-    }
+  componentDidMount() {
+    this.handleResize();
+    window.addEventListener("resize", this.handleResize);
+  }
 
-    componentWillUnmount() {
-      window.removeEventListener("resize", this.handleResize);
-    }
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.handleResize);
+  }
 
-    handleResize() {
-      const draggableGrid =
-        this.gridRulerRef.current.firstChild.getBoundingClientRect().width + 10;
+  handleResize() {
+    const draggableGrid =
+      this.gridRulerRef.current.firstChild.getBoundingClientRect().width + 10;
 
-      if (this.state.draggableGrid !== draggableGrid) {
-        this.setState({
-          draggableGrid,
-        });
-      }
-    }
-
-    onDragStop({ colIndex, deltaColSize }) {
-      if (deltaColSize === 0) {
-        return;
-      }
-
-      const newGrid = [...this.props.currentGrid];
-      newGrid[colIndex] += deltaColSize;
-      newGrid[colIndex + 1] -= deltaColSize;
-
-      this.props.adjustGrid(newGrid);
-    }
-
-    adjustNumberOfColumns(wantedCols) {
-      if (wantedCols > 6 || wantedCols < 1) {
-        return;
-      }
-
-      if (wantedCols === 5) {
-        this.props.adjustGrid([2, 2, 2, 2, 4]);
-        return;
-      }
-
-      const newColSize = 12 / wantedCols;
-      this.props.adjustGrid(times(wantedCols).map(() => newColSize));
-    }
-
-    render() {
-      const gridColumns = this.props.currentGrid.map((colSize, colIndex) => {
-        const innerContent = [
-          <div key="grid-label" className="grid-label">
-            {colSize}
-          </div>,
-        ];
-
-        const nextColSize = this.props.currentGrid[colIndex + 1];
-        if (nextColSize) {
-          const leftBound = -(colSize - 1);
-          const rightBound = nextColSize - 1;
-
-          innerContent.unshift(
-            <Draggable
-              disabled={!Scrivito.canWrite()}
-              key="grid-handle"
-              bounds={{
-                left: this.state.draggableGrid * leftBound,
-                right: this.state.draggableGrid * rightBound,
-              }}
-              axis="x"
-              grid={[this.state.draggableGrid, 0]}
-              position={{ x: 0, y: 0 }}
-              onStop={(_e, { x }) =>
-                this.onDragStop({
-                  colIndex,
-                  deltaColSize: Math.round(x / this.state.draggableGrid),
-                })
-              }
-            >
-              <div className={Scrivito.canWrite() ? "grid-handle" : ""} />
-            </Draggable>
-          );
-        } else if (colIndex < 5 && Scrivito.canWrite()) {
-          innerContent.unshift(
-            <div
-              key="grid-handle-plus"
-              className="grid-handle grid-handle-plus"
-              title="add a column"
-              onClick={() =>
-                this.adjustNumberOfColumns(this.props.currentGrid.length + 1)
-              }
-            />
-          );
-        }
-
-        if (this.props.currentGrid.length > 1 && Scrivito.canWrite()) {
-          innerContent.push(
-            <div
-              key="grid-del"
-              className="grid-del"
-              title="delete column"
-              onClick={() =>
-                this.adjustNumberOfColumns(this.props.currentGrid.length - 1)
-              }
-            />
-          );
-        }
-
-        return (
-          <div
-            key={`grid-col-${colIndex}`}
-            className={`grid-col-${colSize} noselect`}
-          >
-            {innerContent}
-          </div>
-        );
+    if (this.state.draggableGrid !== draggableGrid) {
+      this.setState({
+        draggableGrid,
       });
-
-      return (
-        <div className="gle">
-          <div className="grid-ruler" ref={this.gridRulerRef}>
-            {times(12).map((index) => (
-              <div key={index} className="grid-col" />
-            ))}
-          </div>
-          <div className="grid-columns">{gridColumns}</div>
-        </div>
-      );
     }
   }
-);
+
+  onDragStop({ colIndex, deltaColSize }) {
+    if (deltaColSize === 0) {
+      return;
+    }
+
+    const newGrid = [...this.props.currentGrid];
+    newGrid[colIndex] += deltaColSize;
+    newGrid[colIndex + 1] -= deltaColSize;
+
+    this.props.adjustGrid(newGrid);
+  }
+
+  adjustNumberOfColumns(wantedCols) {
+    if (wantedCols > 6 || wantedCols < 1) {
+      return;
+    }
+
+    if (wantedCols === 5) {
+      this.props.adjustGrid([2, 2, 2, 2, 4]);
+      return;
+    }
+
+    const newColSize = 12 / wantedCols;
+    this.props.adjustGrid(times(wantedCols).map(() => newColSize));
+  }
+
+  render() {
+    const gridColumns = this.props.currentGrid.map((colSize, colIndex) => {
+      const innerContent = [
+        <div key="grid-label" className="grid-label">
+          {colSize}
+        </div>,
+      ];
+
+      const nextColSize = this.props.currentGrid[colIndex + 1];
+      if (nextColSize) {
+        const leftBound = -(colSize - 1);
+        const rightBound = nextColSize - 1;
+
+        innerContent.unshift(
+          <Draggable
+            disabled={this.props.readOnly}
+            key="grid-handle"
+            bounds={{
+              left: this.state.draggableGrid * leftBound,
+              right: this.state.draggableGrid * rightBound,
+            }}
+            axis="x"
+            grid={[this.state.draggableGrid, 0]}
+            position={{ x: 0, y: 0 }}
+            onStop={(_e, { x }) =>
+              this.onDragStop({
+                colIndex,
+                deltaColSize: Math.round(x / this.state.draggableGrid),
+              })
+            }
+          >
+            <div className={this.props.readOnly ? "" : "grid-handle"} />
+          </Draggable>
+        );
+      } else if (colIndex < 5 && !this.props.readOnly) {
+        innerContent.unshift(
+          <div
+            key="grid-handle-plus"
+            className="grid-handle grid-handle-plus"
+            title="add a column"
+            onClick={() =>
+              this.adjustNumberOfColumns(this.props.currentGrid.length + 1)
+            }
+          />
+        );
+      }
+
+      if (this.props.currentGrid.length > 1 && !this.props.readOnly) {
+        innerContent.push(
+          <div
+            key="grid-del"
+            className="grid-del"
+            title="delete column"
+            onClick={() =>
+              this.adjustNumberOfColumns(this.props.currentGrid.length - 1)
+            }
+          />
+        );
+      }
+
+      return (
+        <div
+          key={`grid-col-${colIndex}`}
+          className={`grid-col-${colSize} noselect`}
+        >
+          {innerContent}
+        </div>
+      );
+    });
+
+    return (
+      <div className="gle">
+        <div className="grid-ruler" ref={this.gridRulerRef}>
+          {times(12).map((index) => (
+            <div key={index} className="grid-col" />
+          ))}
+        </div>
+        <div className="grid-columns">{gridColumns}</div>
+      </div>
+    );
+  }
+}
 
 function gridOfWidget(containerWidget) {
   return containerWidget.get("columns").map((column) => column.get("colSize"));

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -142,7 +142,7 @@ Scrivito.registerComponent("ColumnsEditorTab", ColumnsEditorTab);
 
 const PresetGrid = Scrivito.connect(
   ({ currentGrid, adjustGrid, title, grid }) => {
-    const classNames = ["gle-preview"];
+    const classNames = ["gle-preview", "clickable"];
     if (isEqual(currentGrid, grid)) {
       classNames.push("active");
     }
@@ -162,10 +162,10 @@ const PresetGrid = Scrivito.connect(
 );
 
 const Alignment = Scrivito.connect(({ widget }) => {
-  const startAlignmentClasses = ["gle-preview"];
-  const centerAlignmentClasses = ["gle-preview"];
-  const endAlignmentClasses = ["gle-preview"];
-  const stretchAlignmentClasses = ["gle-preview"];
+  const startAlignmentClasses = ["gle-preview", "clickable"];
+  const centerAlignmentClasses = ["gle-preview", "clickable"];
+  const endAlignmentClasses = ["gle-preview", "clickable"];
+  const stretchAlignmentClasses = ["gle-preview", "clickable"];
 
   switch (widget.get("alignment")) {
     case "start":

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -121,6 +121,9 @@ class ColumnsEditorTab extends React.Component {
   }
 
   adjustGrid(newGrid) {
+    if (!Scrivito.canWrite()) {
+      return;
+    }
     if (isEqual(this.state.currentGrid, newGrid)) {
       return;
     }
@@ -142,7 +145,10 @@ Scrivito.registerComponent("ColumnsEditorTab", ColumnsEditorTab);
 
 const PresetGrid = Scrivito.connect(
   ({ currentGrid, adjustGrid, title, grid }) => {
-    const classNames = ["gle-preview", "clickable"];
+    const classNames = ["gle-preview"];
+    if (Scrivito.canWrite()) {
+      classNames.push("clickable");
+    }
     if (isEqual(currentGrid, grid)) {
       classNames.push("active");
     }
@@ -162,10 +168,10 @@ const PresetGrid = Scrivito.connect(
 );
 
 const Alignment = Scrivito.connect(({ widget }) => {
-  const startAlignmentClasses = ["gle-preview", "clickable"];
-  const centerAlignmentClasses = ["gle-preview", "clickable"];
-  const endAlignmentClasses = ["gle-preview", "clickable"];
-  const stretchAlignmentClasses = ["gle-preview", "clickable"];
+  const startAlignmentClasses = ["gle-preview"];
+  const centerAlignmentClasses = ["gle-preview"];
+  const endAlignmentClasses = ["gle-preview"];
+  const stretchAlignmentClasses = ["gle-preview"];
 
   switch (widget.get("alignment")) {
     case "start":
@@ -183,6 +189,13 @@ const Alignment = Scrivito.connect(({ widget }) => {
     default:
       startAlignmentClasses.push("active");
       break;
+  }
+
+  if (Scrivito.canWrite()) {
+    startAlignmentClasses.push("clickable");
+    centerAlignmentClasses.push("clickable");
+    endAlignmentClasses.push("clickable");
+    stretchAlignmentClasses.push("clickable");
   }
 
   return (
@@ -240,6 +253,10 @@ const Alignment = Scrivito.connect(({ widget }) => {
   );
 
   function setAlignment(newAlignment) {
+    if (!Scrivito.canWrite()) {
+      return;
+    }
+
     widget.update({ alignment: newAlignment });
   }
 });
@@ -321,6 +338,7 @@ const GridLayoutEditor = Scrivito.connect(
 
           innerContent.unshift(
             <Draggable
+              disabled={!Scrivito.canWrite()}
               key="grid-handle"
               bounds={{
                 left: this.state.draggableGrid * leftBound,
@@ -336,10 +354,10 @@ const GridLayoutEditor = Scrivito.connect(
                 })
               }
             >
-              <div className="grid-handle" />
+              <div className={Scrivito.canWrite() ? "grid-handle" : ""} />
             </Draggable>
           );
-        } else if (colIndex < 5) {
+        } else if (colIndex < 5 && Scrivito.canWrite()) {
           innerContent.unshift(
             <div
               key="grid-handle-plus"
@@ -352,7 +370,7 @@ const GridLayoutEditor = Scrivito.connect(
           );
         }
 
-        if (this.props.currentGrid.length > 1) {
+        if (this.props.currentGrid.length > 1 && Scrivito.canWrite()) {
           innerContent.push(
             <div
               key="grid-del"

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -196,7 +196,7 @@ const Alignment = Scrivito.connect(({ widget }) => {
             <div
               className={startAlignmentClasses.join(" ")}
               title="Content top aligned"
-              onClick={() => widget.update({ alignment: "start" })}
+              onClick={() => setAlignment("start")}
             >
               <div className="grid-col-12">
                 <span className="alignment" />
@@ -206,7 +206,7 @@ const Alignment = Scrivito.connect(({ widget }) => {
             <div
               className={centerAlignmentClasses.join(" ")}
               title="Content center aligned"
-              onClick={() => widget.update({ alignment: "center" })}
+              onClick={() => setAlignment("center")}
             >
               <div className="grid-col-12">
                 <span className="alignment center" />
@@ -216,7 +216,7 @@ const Alignment = Scrivito.connect(({ widget }) => {
             <div
               className={endAlignmentClasses.join(" ")}
               title="Content bottom aligned"
-              onClick={() => widget.update({ alignment: "end" })}
+              onClick={() => setAlignment("end")}
             >
               <div className="grid-col-12">
                 <span className="alignment bottom" />
@@ -226,7 +226,7 @@ const Alignment = Scrivito.connect(({ widget }) => {
             <div
               className={stretchAlignmentClasses.join(" ")}
               title="Content stretch (full height) aligned"
-              onClick={() => widget.update({ alignment: "stretch" })}
+              onClick={() => setAlignment("stretch")}
             >
               <div className="grid-col-12">
                 <span className="alignment fullHeight" />
@@ -238,6 +238,10 @@ const Alignment = Scrivito.connect(({ widget }) => {
       </div>
     </React.Fragment>
   );
+
+  function setAlignment(newAlignment) {
+    widget.update({ alignment: newAlignment });
+  }
 });
 
 class GridLayoutEditor extends React.Component {

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -22,7 +22,15 @@ class ColumnsEditorTab extends React.Component {
 
     return (
       <div className="scrivito_detail_content">
-        <Alignment widget={this.props.widget} />
+        <Alignment
+          alignment={this.props.widget.get("alignment")}
+          setAlignment={(alignment) => {
+            if (Scrivito.canWrite()) {
+              this.props.widget.update({ alignment });
+            }
+          }}
+          readOnly={readOnly}
+        />
         <div className="scrivito_detail_label">
           <span>Layout (desktop)</span>
         </div>
@@ -180,13 +188,13 @@ function PresetGrid({ currentGrid, adjustGrid, title, grid, readOnly }) {
   );
 }
 
-const Alignment = Scrivito.connect(({ widget }) => {
+function Alignment({ alignment, setAlignment, readOnly }) {
   const startAlignmentClasses = ["gle-preview"];
   const centerAlignmentClasses = ["gle-preview"];
   const endAlignmentClasses = ["gle-preview"];
   const stretchAlignmentClasses = ["gle-preview"];
 
-  switch (widget.get("alignment")) {
+  switch (alignment) {
     case "start":
       startAlignmentClasses.push("active");
       break;
@@ -204,7 +212,7 @@ const Alignment = Scrivito.connect(({ widget }) => {
       break;
   }
 
-  if (Scrivito.canWrite()) {
+  if (!readOnly) {
     startAlignmentClasses.push("clickable");
     centerAlignmentClasses.push("clickable");
     endAlignmentClasses.push("clickable");
@@ -260,19 +268,11 @@ const Alignment = Scrivito.connect(({ widget }) => {
             </div>
           </div>
         </div>
-        <AlignmentDescription alignment={widget.get("alignment")} />
+        <AlignmentDescription alignment={alignment} />
       </div>
     </React.Fragment>
   );
-
-  function setAlignment(newAlignment) {
-    if (!Scrivito.canWrite()) {
-      return;
-    }
-
-    widget.update({ alignment: newAlignment });
-  }
-});
+}
 
 class GridLayoutEditor extends React.Component {
   constructor(props) {

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -189,10 +189,14 @@ function PresetGrid({ currentGrid, adjustGrid, title, grid, readOnly }) {
 }
 
 function Alignment({ alignment, setAlignment, readOnly }) {
-  const startAlignmentClasses = ["gle-preview"];
-  const centerAlignmentClasses = ["gle-preview"];
-  const endAlignmentClasses = ["gle-preview"];
-  const stretchAlignmentClasses = ["gle-preview"];
+  const initialClasses = readOnly
+    ? ["gle-preview"]
+    : ["gle-preview", "clickable"];
+
+  const startAlignmentClasses = [...initialClasses];
+  const centerAlignmentClasses = [...initialClasses];
+  const endAlignmentClasses = [...initialClasses];
+  const stretchAlignmentClasses = [...initialClasses];
 
   switch (alignment) {
     case "start":
@@ -210,13 +214,6 @@ function Alignment({ alignment, setAlignment, readOnly }) {
     default:
       startAlignmentClasses.push("active");
       break;
-  }
-
-  if (!readOnly) {
-    startAlignmentClasses.push("clickable");
-    centerAlignmentClasses.push("clickable");
-    endAlignmentClasses.push("clickable");
-    stretchAlignmentClasses.push("clickable");
   }
 
   return (

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -32,6 +32,7 @@ class ColumnsEditorTab extends React.Component {
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="1 column"
                 grid={[12]}
               />
@@ -40,18 +41,21 @@ class ColumnsEditorTab extends React.Component {
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="2 columns"
                 grid={[6, 6]}
               />
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="2 columns"
                 grid={[3, 9]}
               />
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="2 columns"
                 grid={[9, 3]}
               />
@@ -60,24 +64,28 @@ class ColumnsEditorTab extends React.Component {
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="3 columns"
                 grid={[4, 4, 4]}
               />
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="3 columns"
                 grid={[2, 8, 2]}
               />
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="3 columns"
                 grid={[2, 5, 5]}
               />
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="3 columns"
                 grid={[5, 5, 2]}
               />
@@ -86,12 +94,14 @@ class ColumnsEditorTab extends React.Component {
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="4 columns"
                 grid={[3, 3, 3, 3]}
               />
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="4 columns"
                 grid={[2, 4, 4, 2]}
               />
@@ -100,6 +110,7 @@ class ColumnsEditorTab extends React.Component {
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="5 columns"
                 grid={[2, 2, 2, 2, 4]}
               />
@@ -108,6 +119,7 @@ class ColumnsEditorTab extends React.Component {
               <PresetGrid
                 currentGrid={this.state.currentGrid}
                 adjustGrid={this.adjustGrid}
+                readOnly={readOnly}
                 title="6 columns"
                 grid={[2, 2, 2, 2, 2, 2]}
               />
@@ -146,29 +158,27 @@ class ColumnsEditorTab extends React.Component {
 
 Scrivito.registerComponent("ColumnsEditorTab", ColumnsEditorTab);
 
-const PresetGrid = Scrivito.connect(
-  ({ currentGrid, adjustGrid, title, grid }) => {
-    const classNames = ["gle-preview"];
-    if (Scrivito.canWrite()) {
-      classNames.push("clickable");
-    }
-    if (isEqual(currentGrid, grid)) {
-      classNames.push("active");
-    }
-
-    return (
-      <div
-        className={classNames.join(" ")}
-        title={title}
-        onClick={() => adjustGrid(grid)}
-      >
-        {grid.map((colSize, index) => (
-          <div className={`grid-col-${colSize}`} key={index} />
-        ))}
-      </div>
-    );
+function PresetGrid({ currentGrid, adjustGrid, title, grid, readOnly }) {
+  const classNames = ["gle-preview"];
+  if (!readOnly) {
+    classNames.push("clickable");
   }
-);
+  if (isEqual(currentGrid, grid)) {
+    classNames.push("active");
+  }
+
+  return (
+    <div
+      className={classNames.join(" ")}
+      title={title}
+      onClick={() => adjustGrid(grid)}
+    >
+      {grid.map((colSize, index) => (
+        <div className={`grid-col-${colSize}`} key={index} />
+      ))}
+    </div>
+  );
+}
 
 const Alignment = Scrivito.connect(({ widget }) => {
   const startAlignmentClasses = ["gle-preview"];

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -400,6 +400,10 @@ class GridLayoutEditor extends React.Component {
       );
     });
 
+    const gridColumnsClass = this.props.readOnly
+      ? "grid-columns"
+      : "grid-columns clickable";
+
     return (
       <div className="gle">
         <div className="grid-ruler" ref={this.gridRulerRef}>
@@ -407,7 +411,7 @@ class GridLayoutEditor extends React.Component {
             <div key={index} className="grid-col" />
           ))}
         </div>
-        <div className="grid-columns">{gridColumns}</div>
+        <div className={gridColumnsClass}>{gridColumns}</div>
       </div>
     );
   }

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -167,10 +167,8 @@ class ColumnsEditorTab extends React.Component {
 Scrivito.registerComponent("ColumnsEditorTab", ColumnsEditorTab);
 
 function PresetGrid({ currentGrid, adjustGrid, title, grid, readOnly }) {
-  const classNames = ["gle-preview"];
-  if (!readOnly) {
-    classNames.push("clickable");
-  }
+  const classNames = readOnly ? ["gle-preview"] : ["gle-preview", "clickable"];
+
   if (isEqual(currentGrid, grid)) {
     classNames.push("active");
   }

--- a/src/Components/ScrivitoExtensions/IconEditorTab.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab.js
@@ -19,7 +19,7 @@ function IconEditorTab({ widget }) {
           <IconComponent icon={currentIcon} />
         </div>
 
-        {Scrivito.canWrite() ? (
+        {Scrivito.canWrite() && (
           <>
             <IconSearch
               searchValue={searchValue}
@@ -40,7 +40,7 @@ function IconEditorTab({ widget }) {
               setWidgetIcon={setWidgetIcon}
             />
           </>
-        ) : null}
+        )}
       </div>
     </div>
   );

--- a/src/Components/ScrivitoExtensions/IconEditorTab.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab.js
@@ -13,17 +13,7 @@ class IconEditorTab extends React.Component {
       searchValue: "",
     };
 
-    this.setSearchValue = this.setSearchValue.bind(this);
     this.setWidgetIcon = this.setWidgetIcon.bind(this);
-  }
-
-  setSearchValue(event, searchValue) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    if (this.state.searchValue !== searchValue) {
-      this.setState({ searchValue });
-    }
   }
 
   setWidgetIcon(event, icon) {
@@ -49,7 +39,11 @@ class IconEditorTab extends React.Component {
 
           <IconSearch
             searchValue={this.state.searchValue}
-            setSearchValue={this.setSearchValue}
+            setSearchValue={(newSearchValue) => {
+              if (this.state.searchValue !== newSearchValue) {
+                this.setState({ searchValue: newSearchValue });
+              }
+            }}
           />
           <IconSearchResults
             currentIcon={currentIcon}

--- a/src/Components/ScrivitoExtensions/IconEditorTab.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab.js
@@ -19,24 +19,28 @@ function IconEditorTab({ widget }) {
           <IconComponent icon={currentIcon} />
         </div>
 
-        <IconSearch
-          searchValue={searchValue}
-          setSearchValue={(newSearchValue) => {
-            if (searchValue !== newSearchValue) {
-              setSearchValue(newSearchValue);
-            }
-          }}
-        />
-        <IconSearchResults
-          currentIcon={currentIcon}
-          searchValue={searchValue}
-          setWidgetIcon={setWidgetIcon}
-        />
-        <AllIcons
-          currentIcon={currentIcon}
-          hide={searchValue.length}
-          setWidgetIcon={setWidgetIcon}
-        />
+        {Scrivito.canWrite() ? (
+          <>
+            <IconSearch
+              searchValue={searchValue}
+              setSearchValue={(newSearchValue) => {
+                if (searchValue !== newSearchValue) {
+                  setSearchValue(newSearchValue);
+                }
+              }}
+            />
+            <IconSearchResults
+              currentIcon={currentIcon}
+              searchValue={searchValue}
+              setWidgetIcon={setWidgetIcon}
+            />
+            <AllIcons
+              currentIcon={currentIcon}
+              hide={searchValue.length}
+              setWidgetIcon={setWidgetIcon}
+            />
+          </>
+        ) : null}
       </div>
     </div>
   );

--- a/src/Components/ScrivitoExtensions/IconEditorTab.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab.js
@@ -44,7 +44,7 @@ class IconEditorTab extends React.Component {
             <span>Preview</span>
           </div>
           <div className="icon-editor-preview">
-            <IconComponent icon={widget.get("icon")} />
+            <IconComponent icon={currentIcon} />
           </div>
 
           <IconSearch

--- a/src/Components/ScrivitoExtensions/IconEditorTab.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab.js
@@ -5,59 +5,47 @@ import IconComponent from "../Icon";
 import IconSearch from "./IconEditorTab/IconSearch";
 import IconSearchResults from "./IconEditorTab/IconSearchResults";
 
-class IconEditorTab extends React.Component {
-  constructor(props) {
-    super(props);
+function IconEditorTab({ widget }) {
+  const [searchValue, setSearchValue] = React.useState("");
+  const currentIcon = widget.get("icon");
 
-    this.state = {
-      searchValue: "",
-    };
+  return (
+    <div className="icon-editor-tab">
+      <div className="scrivito_detail_content">
+        <div className="scrivito_detail_label">
+          <span>Preview</span>
+        </div>
+        <div className="icon-editor-preview">
+          <IconComponent icon={currentIcon} />
+        </div>
 
-    this.setWidgetIcon = this.setWidgetIcon.bind(this);
-  }
+        <IconSearch
+          searchValue={searchValue}
+          setSearchValue={(newSearchValue) => {
+            if (searchValue !== newSearchValue) {
+              setSearchValue(newSearchValue);
+            }
+          }}
+        />
+        <IconSearchResults
+          currentIcon={currentIcon}
+          searchValue={searchValue}
+          setWidgetIcon={setWidgetIcon}
+        />
+        <AllIcons
+          currentIcon={currentIcon}
+          hide={searchValue.length}
+          setWidgetIcon={setWidgetIcon}
+        />
+      </div>
+    </div>
+  );
 
-  setWidgetIcon(event, icon) {
+  function setWidgetIcon(event, icon) {
     event.preventDefault();
     event.stopPropagation();
 
-    this.props.widget.update({ icon });
-  }
-
-  render() {
-    const { widget } = this.props;
-    const currentIcon = widget.get("icon");
-
-    return (
-      <div className="icon-editor-tab">
-        <div className="scrivito_detail_content">
-          <div className="scrivito_detail_label">
-            <span>Preview</span>
-          </div>
-          <div className="icon-editor-preview">
-            <IconComponent icon={currentIcon} />
-          </div>
-
-          <IconSearch
-            searchValue={this.state.searchValue}
-            setSearchValue={(newSearchValue) => {
-              if (this.state.searchValue !== newSearchValue) {
-                this.setState({ searchValue: newSearchValue });
-              }
-            }}
-          />
-          <IconSearchResults
-            currentIcon={currentIcon}
-            searchValue={this.state.searchValue}
-            setWidgetIcon={this.setWidgetIcon}
-          />
-          <AllIcons
-            currentIcon={currentIcon}
-            hide={this.state.searchValue.length}
-            setWidgetIcon={this.setWidgetIcon}
-          />
-        </div>
-      </div>
-    );
+    widget.update({ icon });
   }
 }
 

--- a/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
@@ -2,6 +2,16 @@ import * as React from "react";
 import { take } from "lodash-es";
 import fontAwesomeIcons from "./fontAwesomeIcons";
 
+const categoryMap = {};
+fontAwesomeIcons.forEach((icon) =>
+  icon.categories.forEach((category) => {
+    if (!categoryMap[category]) {
+      categoryMap[category] = [];
+    }
+    categoryMap[category].push(icon);
+  })
+);
+
 class AllIcons extends React.Component {
   constructor(props) {
     super(props);
@@ -9,16 +19,6 @@ class AllIcons extends React.Component {
     this.state = {
       initialRender: true,
     };
-
-    this.categoryMap = {};
-    fontAwesomeIcons.forEach((icon) =>
-      icon.categories.forEach((category) => {
-        if (!this.categoryMap[category]) {
-          this.categoryMap[category] = [];
-        }
-        this.categoryMap[category].push(icon);
-      })
-    );
   }
 
   componentDidMount() {
@@ -40,7 +40,6 @@ class AllIcons extends React.Component {
           {
             <CategoriesAndIcons
               initialRender={this.state.initialRender}
-              categoryMap={this.categoryMap}
               currentIcon={currentIcon}
               setWidgetIcon={setWidgetIcon}
             />
@@ -51,12 +50,7 @@ class AllIcons extends React.Component {
   }
 }
 
-function CategoriesAndIcons({
-  initialRender,
-  categoryMap,
-  currentIcon,
-  setWidgetIcon,
-}) {
+function CategoriesAndIcons({ initialRender, currentIcon, setWidgetIcon }) {
   // Note: the initialRender is a performance tweak,
   // to improve loading time for first "meaningful content".
   // It is faster, because it first renders only the first 50 icons

--- a/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
@@ -12,42 +12,29 @@ fontAwesomeIcons.forEach((icon) =>
   })
 );
 
-class AllIcons extends React.Component {
-  constructor(props) {
-    super(props);
+function AllIcons({ setWidgetIcon, currentIcon, hide }) {
+  const [initialRender, setInitialRender] = React.useState(true);
+  React.useEffect(() => {
+    setTimeout(() => setInitialRender(false), 10);
+  }, []);
 
-    this.state = {
-      initialRender: true,
-    };
+  if (hide) {
+    return null;
   }
 
-  componentDidMount() {
-    if (this.state.initialRender === true) {
-      setTimeout(() => this.setState({ initialRender: false }), 10);
-    }
-  }
-
-  render() {
-    const { setWidgetIcon, currentIcon, hide } = this.props;
-
-    if (hide) {
-      return null;
-    }
-
-    return (
-      <React.Fragment>
-        <div id="icons">
-          {
-            <CategoriesAndIcons
-              initialRender={this.state.initialRender}
-              currentIcon={currentIcon}
-              setWidgetIcon={setWidgetIcon}
-            />
-          }
-        </div>
-      </React.Fragment>
-    );
-  }
+  return (
+    <React.Fragment>
+      <div id="icons">
+        {
+          <CategoriesAndIcons
+            initialRender={initialRender}
+            currentIcon={currentIcon}
+            setWidgetIcon={setWidgetIcon}
+          />
+        }
+      </div>
+    </React.Fragment>
+  );
 }
 
 function CategoriesAndIcons({ initialRender, currentIcon, setWidgetIcon }) {

--- a/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
@@ -2,18 +2,22 @@ import * as React from "react";
 import { take } from "lodash-es";
 import fontAwesomeIcons from "./fontAwesomeIcons";
 
-const categoryMap = {};
-fontAwesomeIcons.forEach((icon) =>
-  icon.categories.forEach((category) => {
-    if (!categoryMap[category]) {
-      categoryMap[category] = [];
-    }
-    categoryMap[category].push(icon);
-  })
-);
-
 function AllIcons({ setWidgetIcon, currentIcon, hide }) {
   const [initialRender, setInitialRender] = React.useState(true);
+
+  const categoryMap = React.useMemo(() => {
+    const result = {};
+    fontAwesomeIcons.forEach((icon) =>
+      icon.categories.forEach((category) => {
+        if (!result[category]) {
+          result[category] = [];
+        }
+        result[category].push(icon);
+      })
+    );
+    return result;
+  }, []);
+
   React.useEffect(() => {
     setTimeout(() => setInitialRender(false), 10);
   }, []);
@@ -28,6 +32,7 @@ function AllIcons({ setWidgetIcon, currentIcon, hide }) {
         {
           <CategoriesAndIcons
             initialRender={initialRender}
+            categoryMap={categoryMap}
             currentIcon={currentIcon}
             setWidgetIcon={setWidgetIcon}
           />
@@ -37,7 +42,12 @@ function AllIcons({ setWidgetIcon, currentIcon, hide }) {
   );
 }
 
-function CategoriesAndIcons({ initialRender, currentIcon, setWidgetIcon }) {
+function CategoriesAndIcons({
+  initialRender,
+  categoryMap,
+  currentIcon,
+  setWidgetIcon,
+}) {
   // Note: the initialRender is a performance tweak,
   // to improve loading time for first "meaningful content".
   // It is faster, because it first renders only the first 50 icons

--- a/src/Components/ScrivitoExtensions/IconEditorTab/IconSearch.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/IconSearch.js
@@ -16,7 +16,12 @@ function IconSearch({ setSearchValue, searchValue }) {
         autoCorrect="off"
         tabIndex="1"
         value={searchValue}
-        onChange={(e) => setSearchValue(e, e.target.value)}
+        onChange={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          setSearchValue(event.target.value);
+        }}
       />
       <ClearSearchButton
         setSearchValue={setSearchValue}

--- a/src/Components/ScrivitoExtensions/IconEditorTab/IconSearchResults.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/IconSearchResults.js
@@ -3,48 +3,43 @@ import Fuse from "fuse.js";
 import fontAwesomeIcons from "./fontAwesomeIcons";
 import SingleIcon from "./SingleIcon";
 
-class IconSearchResults extends React.Component {
-  constructor(props) {
-    super(props);
-
+function IconSearchResults({ searchValue, setWidgetIcon, currentIcon }) {
+  const fuse = React.useMemo(() => {
     const fuseOptions = {
       threshold: 0.2,
       keys: ["name", "id", "filter", "aliases"],
     };
-    this.fuse = new Fuse(fontAwesomeIcons, fuseOptions);
+
+    return new Fuse(fontAwesomeIcons, fuseOptions);
+  }, []);
+
+  if (!searchValue.length) {
+    return null;
   }
 
-  render() {
-    const { searchValue, setWidgetIcon, currentIcon } = this.props;
+  const results = fuse.search(searchValue);
 
-    if (!searchValue.length) {
-      return null;
-    }
-
-    const results = this.fuse.search(searchValue);
-
-    return (
-      <div id="search-results">
-        <div className="scrivito_detail_label">
-          <span>{`Search for '${searchValue}'`}</span>
-        </div>
-        <div className="row">
-          {results.map((result, index) => {
-            const icon = result.item;
-
-            return (
-              <SingleIcon
-                key={`${icon.id}${index}`}
-                icon={icon}
-                currentIcon={currentIcon}
-                setWidgetIcon={setWidgetIcon}
-              />
-            );
-          })}
-        </div>
+  return (
+    <div id="search-results">
+      <div className="scrivito_detail_label">
+        <span>{`Search for '${searchValue}'`}</span>
       </div>
-    );
-  }
+      <div className="row">
+        {results.map((result, index) => {
+          const icon = result.item;
+
+          return (
+            <SingleIcon
+              key={`${icon.id}${index}`}
+              icon={icon}
+              currentIcon={currentIcon}
+              setWidgetIcon={setWidgetIcon}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 export default IconSearchResults;

--- a/src/assets/stylesheets/_grid_layout_editor.scss
+++ b/src/assets/stylesheets/_grid_layout_editor.scss
@@ -22,6 +22,8 @@
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
   height: 25px;
   width: 40px;
+}
+.gle-preview.clickable {
   cursor: pointer;
 }
 .gle-preview.active {
@@ -73,7 +75,7 @@
   width: calc(100% - 2px);
 }
 
-.gle-preview:hover > [class*="grid-col-"] {
+.gle-preview.clickable:hover > [class*="grid-col-"] {
   box-shadow: 0 0 0 1px rgba(101, 139, 81, 0.5) inset;
   background: rgba(101, 139, 81, 0.3);
 }

--- a/src/assets/stylesheets/_grid_layout_editor.scss
+++ b/src/assets/stylesheets/_grid_layout_editor.scss
@@ -178,7 +178,7 @@
   left: 0;
   margin: 0 -5px;
 }
-.gle .grid-columns:hover {
+.gle .grid-columns.clickable:hover {
   opacity: 1;
 }
 .gle .grid-columns > [class*="grid-col-"] {
@@ -189,7 +189,7 @@
   margin: 0 5px;
   @include transition(all 0.3s ease-in-out);
 }
-.gle .grid-columns:hover > [class*="grid-col-"] {
+.gle .grid-columns.clickable:hover > [class*="grid-col-"] {
   border: 2px solid #658b51;
 }
 
@@ -244,11 +244,11 @@
   z-index: 2;
   @include transition(all 0.1s ease-in-out);
 }
-.gle .grid-columns:hover .grid-handle {
+.gle .grid-columns.clickable:hover .grid-handle {
   background: #658b51;
   border: none;
 }
-.gle .grid-columns:hover .grid-handle:after {
+.gle .grid-columns.clickable:hover .grid-handle:after {
   color: #fff;
 }
 .gle .grid-columns > [class*="grid-col-"]:last-child .grid-handle {


### PR DESCRIPTION
IconEditorTab and ColumnsEditorTab should both be be usable in a "read-only" mode.

This is checked using [`Scrivito.canWrite()`](https://www.scrivito.com/js-sdk/canWrite).

IconEditorTab was also converted to React Hooks.

Diff best viewed without whitespace changes.

### Screenshots

<img width="1000" alt="Read only icon editor" src="https://user-images.githubusercontent.com/86275/123958151-00beb580-d9ad-11eb-804b-001f025abe70.png">
<img width="1007" alt="Read only columns editor" src="https://user-images.githubusercontent.com/86275/123958156-01efe280-d9ad-11eb-98c4-76a1ab5e8574.png">
