### PR TITLE
CookieConsent: Treat denied localStorage as "declined" cookie banner.

### DIFF
--- a/src/Components/CookieConsentContext.js
+++ b/src/Components/CookieConsentContext.js
@@ -33,5 +33,14 @@ export function useCookieConsent() {
 }
 
 function getCookieConsent() {
-  return localStorage.getItem("CookieConsent") || "undecided";
+  try {
+    return localStorage.getItem("CookieConsent") || "undecided";
+  } catch (e) {
+    if (e instanceof DOMException) {
+      // Prevent "Uncaught DOMException: Failed to read the 'localStorage' property from 'Window': Access is denied for this document."
+      return "declined";
+    }
+
+    throw e;
+  }
 }

--- a/src/Objs/Homepage/HomepageEditingConfig.js
+++ b/src/Objs/Homepage/HomepageEditingConfig.js
@@ -70,9 +70,9 @@ Scrivito.provideEditingConfig("Homepage", {
       ],
     },
     cookieConsentLink: {
-      title: "Cookie consent link",
+      title: "Privacy policy for cookie consent",
       description:
-        'If you set this link, a cookie consent box will be shown on every page. The link should point to your privacy policy. The link title defaults to "Learn more »".',
+        'If you set this link, a cookie consent box will be shown on every page. To preview the effect of this setting, please enable third-party cookies in your browser. The link title defaults to "Learn more »".',
     },
   },
   properties: [...defaultPageProperties, "showAsLandingPage"],


### PR DESCRIPTION
Google Chrome seems to treat direct access to "localStorage" in an iframe in incognito as a "third party cookie" and blocks it (see [1]).

[1] https://github.com/elastic/kibana/issues/87901#issuecomment-758457425