### PR TITLE
Columns editor: Read only mode in case of concurrent edits

### DIFF
--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -4,163 +4,150 @@ import Draggable from "react-draggable";
 import { flatten, isEqual, last, take, takeRight, times } from "lodash-es";
 import ColumnWidget from "../../Widgets/ColumnWidget/ColumnWidgetClass";
 
-class ColumnsEditorTab extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      originalContents: props.widget
-        .get("columns")
-        .map((column) => column.get("content")),
-      currentGrid: gridOfWidget(props.widget),
-    };
+function ColumnsEditorTab({ widget }) {
+  const originalContents = React.useMemo(
+    () => widget.get("columns").map((column) => column.get("content")),
+    [widget]
+  );
+  const [currentGrid, setCurrentGrid] = React.useState(gridOfWidget(widget));
 
-    this.adjustGrid = this.adjustGrid.bind(this);
-  }
+  const readOnly = !Scrivito.canWrite();
 
-  render() {
-    const readOnly = !Scrivito.canWrite();
-
-    return (
-      <div className="scrivito_detail_content">
-        <Alignment
-          alignment={this.props.widget.get("alignment")}
-          setAlignment={(alignment) => {
-            if (Scrivito.canWrite()) {
-              this.props.widget.update({ alignment });
-            }
-          }}
+  return (
+    <div className="scrivito_detail_content">
+      <Alignment
+        alignment={widget.get("alignment")}
+        setAlignment={(alignment) => {
+          if (Scrivito.canWrite()) {
+            widget.update({ alignment });
+          }
+        }}
+        readOnly={readOnly}
+      />
+      <div className="scrivito_detail_label">
+        <span>Layout (desktop)</span>
+      </div>
+      <div className="item_content">
+        <div className="gle-preview-list">
+          <div className="gle-preview-group">
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="1 column"
+              grid={[12]}
+            />
+          </div>
+          <div className="gle-preview-group">
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="2 columns"
+              grid={[6, 6]}
+            />
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="2 columns"
+              grid={[3, 9]}
+            />
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="2 columns"
+              grid={[9, 3]}
+            />
+          </div>
+          <div className="gle-preview-group">
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="3 columns"
+              grid={[4, 4, 4]}
+            />
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="3 columns"
+              grid={[2, 8, 2]}
+            />
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="3 columns"
+              grid={[2, 5, 5]}
+            />
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="3 columns"
+              grid={[5, 5, 2]}
+            />
+          </div>
+          <div className="gle-preview-group">
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="4 columns"
+              grid={[3, 3, 3, 3]}
+            />
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="4 columns"
+              grid={[2, 4, 4, 2]}
+            />
+          </div>
+          <div className="gle-preview-group">
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="5 columns"
+              grid={[2, 2, 2, 2, 4]}
+            />
+          </div>
+          <div className="gle-preview-group">
+            <PresetGrid
+              currentGrid={currentGrid}
+              adjustGrid={adjustGrid}
+              readOnly={readOnly}
+              title="6 columns"
+              grid={[2, 2, 2, 2, 2, 2]}
+            />
+          </div>
+        </div>
+        <GridLayoutEditor
+          currentGrid={currentGrid}
+          adjustGrid={adjustGrid}
           readOnly={readOnly}
         />
-        <div className="scrivito_detail_label">
-          <span>Layout (desktop)</span>
-        </div>
-        <div className="item_content">
-          <div className="gle-preview-list">
-            <div className="gle-preview-group">
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="1 column"
-                grid={[12]}
-              />
-            </div>
-            <div className="gle-preview-group">
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="2 columns"
-                grid={[6, 6]}
-              />
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="2 columns"
-                grid={[3, 9]}
-              />
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="2 columns"
-                grid={[9, 3]}
-              />
-            </div>
-            <div className="gle-preview-group">
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="3 columns"
-                grid={[4, 4, 4]}
-              />
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="3 columns"
-                grid={[2, 8, 2]}
-              />
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="3 columns"
-                grid={[2, 5, 5]}
-              />
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="3 columns"
-                grid={[5, 5, 2]}
-              />
-            </div>
-            <div className="gle-preview-group">
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="4 columns"
-                grid={[3, 3, 3, 3]}
-              />
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="4 columns"
-                grid={[2, 4, 4, 2]}
-              />
-            </div>
-            <div className="gle-preview-group">
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="5 columns"
-                grid={[2, 2, 2, 2, 4]}
-              />
-            </div>
-            <div className="gle-preview-group">
-              <PresetGrid
-                currentGrid={this.state.currentGrid}
-                adjustGrid={this.adjustGrid}
-                readOnly={readOnly}
-                title="6 columns"
-                grid={[2, 2, 2, 2, 2, 2]}
-              />
-            </div>
-          </div>
-          <GridLayoutEditor
-            currentGrid={this.state.currentGrid}
-            adjustGrid={this.adjustGrid}
-            readOnly={readOnly}
-          />
-        </div>
       </div>
-    );
-  }
+    </div>
+  );
 
-  adjustGrid(newGrid) {
+  function adjustGrid(newGrid) {
     if (!Scrivito.canWrite()) {
       return;
     }
-    if (isEqual(this.state.currentGrid, newGrid)) {
+    if (isEqual(currentGrid, newGrid)) {
       return;
     }
 
-    const containerWidget = this.props.widget;
+    adjustNumberOfColumns(widget, newGrid.length);
+    distributeContents(widget.get("columns"), originalContents);
+    adjustColSize(widget.get("columns"), newGrid);
 
-    adjustNumberOfColumns(containerWidget, newGrid.length);
-    distributeContents(
-      containerWidget.get("columns"),
-      this.state.originalContents
-    );
-    adjustColSize(containerWidget.get("columns"), newGrid);
-
-    this.setState({ currentGrid: gridOfWidget(containerWidget) });
+    setCurrentGrid(gridOfWidget(widget));
   }
 }
 

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -9,8 +9,8 @@ function ColumnsEditorTab({ widget }) {
     () => widget.get("columns").map((column) => column.get("content")),
     [widget]
   );
-  const [currentGrid, setCurrentGrid] = React.useState(gridOfWidget(widget));
 
+  const currentGrid = gridOfWidget(widget);
   const readOnly = !Scrivito.canWrite();
 
   return (
@@ -146,8 +146,6 @@ function ColumnsEditorTab({ widget }) {
     adjustNumberOfColumns(widget, newGrid.length);
     distributeContents(widget.get("columns"), originalContents);
     adjustColSize(widget.get("columns"), newGrid);
-
-    setCurrentGrid(gridOfWidget(widget));
   }
 }
 

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -18,7 +18,7 @@ function ColumnsEditorTab({ widget }) {
       <Alignment
         alignment={widget.get("alignment")}
         setAlignment={(alignment) => {
-          if (Scrivito.canWrite()) {
+          if (!readOnly) {
             widget.update({ alignment });
           }
         }}
@@ -136,7 +136,7 @@ function ColumnsEditorTab({ widget }) {
   );
 
   function adjustGrid(newGrid) {
-    if (!Scrivito.canWrite()) {
+    if (readOnly) {
       return;
     }
     if (isEqual(currentGrid, newGrid)) {


### PR DESCRIPTION
This is an alternative approach to #415: Instead of still allowing to edit in the columns editor while concurrent changes are taking place, in my eyes it's better to switch the columns editor into readOnly mode.

This ensures that deleted widgets are handled, but also that newly created widgets are not being deleted.

Fixes #414. Closes #415.