### PR TITLE
Add a validation for googleAnalyticsTrackingId.

### DIFF
--- a/src/Objs/Homepage/HomepageEditingConfig.js
+++ b/src/Objs/Homepage/HomepageEditingConfig.js
@@ -99,5 +99,17 @@ Scrivito.provideEditingConfig("Homepage", {
     ...metadataInitialContent,
     showAsLandingPage: "no",
   },
-  validations: [...defaultPageValidations, ...metadataValidations],
+  validations: [
+    ...defaultPageValidations,
+    ...metadataValidations,
+    [
+      "googleAnalyticsTrackingId",
+
+      (trackingId) => {
+        if (trackingId && !trackingId.startsWith("UA-")) {
+          return 'Provide a Universal Analytics property (starts with "UA-"). See https://support.google.com/analytics/answer/10269537 for details.';
+        }
+      },
+    ],
+  ],
 });


### PR DESCRIPTION
<img width="963" alt="Google Analytics Validation" src="https://user-images.githubusercontent.com/86275/145361399-56a10cb6-e428-4aed-a89b-1e114aeee0e6.png">

Google Analytics 4 (see [1]) is currently not supported (IDs starting with "G-"). Previous version of Google Analytics continue to work (now called "Universal Analytics property, IDs starting with "UA-") (see [2]). 

[1] https://support.google.com/analytics/answer/10447272
[1] https://support.google.com/analytics/answer/10269537