### PR TITLE
Make generated HTML files more Netlify/SEO friendly

### DIFF
--- a/src/prerenderContent/filenameFromUrl.js
+++ b/src/prerenderContent/filenameFromUrl.js
@@ -4,5 +4,5 @@ export default function filenameFromUrl(url) {
     return "/index.html";
   }
 
-  return `${pathname}/index.html`;
+  return `${pathname}.html`;
 }


### PR DESCRIPTION

This reverts commit 4ba5561124ed7144fd42978b45822b6c661a8363.

We've learned that while the `index.html` filename schema is less prone
to clashes and is better suited for serving on S3, it has an unwanted
SEO impact on Netlify:

The canonical URLs of Scrivito _don't_ use a trailing slash.
Netlify implements the `index.html` schema _with_ a trailing slash.
Thus, requests to the canonical URL cause an unnecessary 301 on Netlify.

With this change, requests to the canonical URL are served as 200 OK.

Some background:

* https://docs.netlify.com/routing/redirects/redirect-options/#trailing-slash
* https://github.com/gatsbyjs/gatsby/discussions/27889#discussioncomment-254854