### PR TITLE
BlogPost: Allow publishedAt to be more precise (date => datetime)

### DIFF
--- a/src/Objs/BlogPost/BlogPostObjClass.js
+++ b/src/Objs/BlogPost/BlogPostObjClass.js
@@ -5,7 +5,7 @@ const BlogPost = Scrivito.provideObjClass("BlogPost", {
   attributes: {
     author: ["reference", { only: "Author" }],
     body: ["widgetlist", { only: "SectionWidget" }],
-    publishedAt: "date",
+    publishedAt: "datetime",
     subtitle: "string",
     tags: "stringlist",
     title: "string",


### PR DESCRIPTION
Since Scrivito 1.15.0 `datetime` is supported (see https://www.scrivito.com/scrivito-js-1-15-0-released-featuring-dates-of-first-and-most-recent-publish-4f277ce06c513361). This allows to give an exact order for blog posts published on the same day.