### PR TITLE
Don't override Bootstrap `btn-lg`/`btn-sm` font size

### DIFF
--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -341,12 +341,11 @@ small,
   position: initial !important;
 }
 
-/* button adaoptions
+/* button adaptions
 =================================================================== */
 
 .btn {
   border-radius: 0;
-  font-size: 16px;
   font-weight: 700;
   text-transform: uppercase;
   vertical-align: middle;


### PR DESCRIPTION
Overriding `.btn` unfortunately also overrides `.btn-sm` and `.btn-lg`.
Now we stick with the default Bootstrap button font size of 1rem,
which should equal 16px.