### PR TITLE
Bugfix: BlogPostNavigation can handle same date blog posts

### DIFF
--- a/src/Components/BlogPost/BlogPostNavigation.js
+++ b/src/Components/BlogPost/BlogPostNavigation.js
@@ -33,11 +33,21 @@ const BlogPostNavigation = Scrivito.connect(({ currentPost }) => {
 const BlogPostNextLink = Scrivito.connect(({ currentBlogPost }) => {
   const currentDate = currentBlogPost.get("publishedAt");
 
-  // find greater than publishedAt
-  const newerPost = Scrivito.getClass("BlogPost")
-    .where("publishedAt", "isGreaterThan", currentDate)
-    .order("publishedAt", "asc")
+  const sameDateNextBlogPost = Scrivito.getClass("BlogPost")
+    .where("publishedAt", "equals", currentDate)
+    .and("_id", "isGreaterThan", currentBlogPost.id())
+    .order(["_id", "asc"])
     .first();
+
+  const newerPost =
+    sameDateNextBlogPost ||
+    Scrivito.getClass("BlogPost")
+      .where("publishedAt", "isGreaterThan", currentDate)
+      .order([
+        ["publishedAt", "asc"],
+        ["_id", "asc"],
+      ])
+      .first();
 
   if (!newerPost) {
     return null;
@@ -53,13 +63,21 @@ const BlogPostNextLink = Scrivito.connect(({ currentBlogPost }) => {
 const BlogPostPreviousLink = Scrivito.connect(({ currentBlogPost }) => {
   const currentDate = currentBlogPost.get("publishedAt");
 
-  // find less than or equal publishedAt
-  const olderPost = Scrivito.getClass("BlogPost")
-    .all()
-    .andNot("id", "equals", currentBlogPost.id())
-    .andNot("publishedAt", "isGreaterThan", currentDate)
-    .order("publishedAt", "desc")
+  const sameDatePreviousBlogPost = Scrivito.getClass("BlogPost")
+    .where("publishedAt", "equals", currentDate)
+    .and("_id", "isLessThan", currentBlogPost.id())
+    .order(["_id", "desc"])
     .first();
+
+  const olderPost =
+    sameDatePreviousBlogPost ||
+    Scrivito.getClass("BlogPost")
+      .where("publishedAt", "isLessThan", currentDate)
+      .order([
+        ["publishedAt", "desc"],
+        ["_id", "desc"],
+      ])
+      .first();
 
   if (!olderPost) {
     return null;

--- a/src/Components/BlogPost/BlogPostNavigation.js
+++ b/src/Components/BlogPost/BlogPostNavigation.js
@@ -36,7 +36,7 @@ const BlogPostNextLink = Scrivito.connect(({ currentBlogPost }) => {
   const sameDateNextBlogPost = Scrivito.getClass("BlogPost")
     .where("publishedAt", "equals", currentDate)
     .and("_id", "isGreaterThan", currentBlogPost.id())
-    .order(["_id", "asc"])
+    .order("_id", "asc")
     .first();
 
   const newerPost =
@@ -66,7 +66,7 @@ const BlogPostPreviousLink = Scrivito.connect(({ currentBlogPost }) => {
   const sameDatePreviousBlogPost = Scrivito.getClass("BlogPost")
     .where("publishedAt", "equals", currentDate)
     .and("_id", "isLessThan", currentBlogPost.id())
-    .order(["_id", "desc"])
+    .order("_id", "desc")
     .first();
 
   const olderPost =

--- a/src/Components/BlogPost/BlogPostPreviewList.js
+++ b/src/Components/BlogPost/BlogPostPreviewList.js
@@ -10,7 +10,10 @@ const BlogPostPreviewList = Scrivito.connect(
   ({ maxItems, author, tag, filterBlogPostId }) => {
     let blogPosts = Scrivito.getClass("BlogPost")
       .all()
-      .order("publishedAt", "desc");
+      .order([
+        ["publishedAt", "desc"],
+        ["_id", "desc"],
+      ]);
     if (author) {
       blogPosts = blogPosts.and("author", "refersTo", author);
     }


### PR DESCRIPTION
Previously the navigation did not work reliably, if one or more "publishedAt" had the exact same value (e.g. three blog posts all starting at the same day). Now this is fixed by also checking for "same date" entries.