### PR TITLE
[webpack] Fixed css auto-reload issue.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,7 +142,9 @@ function webpackConfig(env = {}) {
         ],
       }),
       new MiniCssExtractPlugin({
-        filename: "assets/[name].[contenthash].css",
+        filename: env.production
+          ? "assets/[name].[contenthash].css"
+          : "assets/[name].css",
       }),
       new HtmlWebpackPlugin({
         filename: "catch_all_index.html",


### PR DESCRIPTION
Previously css changes where only visible after a manual refresh of the page - quite annoying. Now css is automatically refreshed on save - similar to js.

It looks like, that this is actually an issue of "html-webpack-plugin" with "contenthash". See https://github.com/jantimon/html-webpack-plugin/issues/1638 . This is more a workaround than an actual fix.