### PR TITLE
Curly only on multi-line

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,7 +47,7 @@
         ]
       }
     ],
-    "curly": [1, "all"],
+    "curly": [1, "multi-line"],
     "import/no-amd": 2,
     "import/no-commonjs": 2,
     "import/no-nodejs-modules": 2,

--- a/src/Components/BlogPost/BlogPostAuthor.js
+++ b/src/Components/BlogPost/BlogPostAuthor.js
@@ -4,12 +4,8 @@ import AuthorImage from "../AuthorImage";
 import isImage from "../../utils/isImage";
 
 function BlogPostAuthor({ author }) {
-  if (!author) {
-    return null;
-  }
-  if (author.objClass() !== "Author") {
-    return null;
-  }
+  if (!author) return null;
+  if (author.objClass() !== "Author") return null;
 
   return (
     <section className="bg-white">

--- a/src/Components/BlogPost/BlogPostDate.js
+++ b/src/Components/BlogPost/BlogPostDate.js
@@ -4,10 +4,7 @@ import formatDate from "../../utils/formatDate";
 
 function BlogPostDate({ post }) {
   const date = post.get("publishedAt");
-
-  if (!date) {
-    return null;
-  }
+  if (!date) return null;
 
   return (
     <Scrivito.ContentTag

--- a/src/Components/BlogPost/BlogPostMorePosts.js
+++ b/src/Components/BlogPost/BlogPostMorePosts.js
@@ -3,12 +3,8 @@ import * as Scrivito from "scrivito";
 import BlogPostPreviewList from "./BlogPostPreviewList";
 
 function BlogPostMorePosts({ author, filterBlogPostId }) {
-  if (!author) {
-    return null;
-  }
-  if (author.objClass() !== "Author") {
-    return null;
-  }
+  if (!author) return null;
+  if (author.objClass() !== "Author") return null;
 
   return (
     <section className="bg-white">

--- a/src/Components/BlogPost/BlogPostNavigation.js
+++ b/src/Components/BlogPost/BlogPostNavigation.js
@@ -3,9 +3,7 @@ import * as Scrivito from "scrivito";
 import BlogPostDate from "./BlogPostDate";
 
 const BlogPostNavigation = Scrivito.connect(({ currentPost }) => {
-  if (!currentPost || !currentPost.get("publishedAt")) {
-    return null;
-  }
+  if (!currentPost || !currentPost.get("publishedAt")) return null;
 
   return (
     <section className="bg-nav-content">
@@ -49,9 +47,7 @@ const BlogPostNextLink = Scrivito.connect(({ currentBlogPost }) => {
       ])
       .first();
 
-  if (!newerPost) {
-    return null;
-  }
+  if (!newerPost) return null;
 
   return (
     <Scrivito.LinkTag to={newerPost}>
@@ -79,9 +75,7 @@ const BlogPostPreviousLink = Scrivito.connect(({ currentBlogPost }) => {
       ])
       .first();
 
-  if (!olderPost) {
-    return null;
-  }
+  if (!olderPost) return null;
 
   return (
     <Scrivito.LinkTag to={olderPost}>

--- a/src/Components/BlogPost/BlogPostPreviewList.js
+++ b/src/Components/BlogPost/BlogPostPreviewList.js
@@ -14,12 +14,8 @@ const BlogPostPreviewList = Scrivito.connect(
         ["publishedAt", "desc"],
         ["_id", "desc"],
       ]);
-    if (author) {
-      blogPosts = blogPosts.and("author", "refersTo", author);
-    }
-    if (tag) {
-      blogPosts = blogPosts.and("tags", "equals", tag);
-    }
+    if (author) blogPosts = blogPosts.and("author", "refersTo", author);
+    if (tag) blogPosts = blogPosts.and("tags", "equals", tag);
     if (filterBlogPostId) {
       blogPosts = blogPosts.andNot("id", "equals", filterBlogPostId);
     }
@@ -58,9 +54,7 @@ const BlogPostPreviewList = Scrivito.connect(
 );
 
 const MonthHeadline = Scrivito.connect(({ date }) => {
-  if (!date) {
-    return null;
-  }
+  if (!date) return null;
 
   return (
     <div className="blog-timeline--divider">
@@ -108,9 +102,7 @@ const BlogPostPreview = Scrivito.connect(({ post }) => (
 
 const BlogPostTitleImage = Scrivito.connect(({ post }) => {
   const titleImage = post.get("titleImage");
-  if (!isImage(titleImage)) {
-    return null;
-  }
+  if (!isImage(titleImage)) return null;
 
   return (
     <Scrivito.LinkTag to={post}>

--- a/src/Components/CookieConsentBanner.js
+++ b/src/Components/CookieConsentBanner.js
@@ -13,9 +13,7 @@ function CookieConsentBanner() {
     setVisible(cookieConsentChoice === "undecided");
   }, [cookieConsentChoice]);
 
-  if (!visible || !consentUrl) {
-    return null;
-  }
+  if (!visible || !consentUrl) return null;
 
   return (
     <CookieBanner
@@ -75,15 +73,11 @@ function CookieBanner(props) {
 function cookieConsentUrl() {
   const root = Scrivito.Obj.root();
 
-  if (!root) {
-    return null;
-  }
+  if (!root) return null;
 
   const cookieConsentLink = root.get("cookieConsentLink");
 
-  if (!cookieConsentLink) {
-    return null;
-  }
+  if (!cookieConsentLink) return null;
 
   return {
     url: Scrivito.urlFor(cookieConsentLink),

--- a/src/Components/ErrorBoundary.js
+++ b/src/Components/ErrorBoundary.js
@@ -13,9 +13,7 @@ class ErrorBoundary extends React.Component {
   }
 
   render() {
-    if (!this.state.hasError) {
-      return this.props.children;
-    }
+    if (!this.state.hasError) return this.props.children;
 
     return (
       <React.Fragment>

--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -4,10 +4,7 @@ import InPlaceEditingPlaceholder from "./InPlaceEditingPlaceholder";
 
 function Footer() {
   const root = Scrivito.Obj.root();
-
-  if (!root) {
-    return null;
-  }
+  if (!root) return null;
 
   return (
     <React.Fragment>

--- a/src/Components/Icon.js
+++ b/src/Components/Icon.js
@@ -13,9 +13,7 @@ function Icon({ icon, size, title }) {
 }
 
 function IconComponent({ icon, size, link }) {
-  if (!link) {
-    return <Icon icon={icon} size={size} />;
-  }
+  if (!link) return <Icon icon={icon} size={size} />;
 
   const title = link.title() || "";
 

--- a/src/Components/InPlaceEditingPlaceholder.js
+++ b/src/Components/InPlaceEditingPlaceholder.js
@@ -3,19 +3,13 @@ import * as Scrivito from "scrivito";
 import placeholderCss from "../utils/placeholderCss";
 
 const InPlaceEditingPlaceholder = ({ children, center, block }) => {
-  if (!Scrivito.isInPlaceEditingActive()) {
-    return null;
-  }
+  if (!Scrivito.isInPlaceEditingActive()) return null;
 
   const innerSpan = <span style={placeholderCss}>{children}</span>;
 
-  if (center) {
-    return <div className="text-center">{innerSpan}</div>;
-  }
+  if (center) return <div className="text-center">{innerSpan}</div>;
 
-  if (block) {
-    return <div>{innerSpan}</div>;
-  }
+  if (block) return <div>{innerSpan}</div>;
 
   return innerSpan;
 };

--- a/src/Components/Intercom.js
+++ b/src/Components/Intercom.js
@@ -12,9 +12,7 @@ class Intercom extends React.Component {
   componentDidMount() {
     Scrivito.load(() => {
       const rootPage = Scrivito.Obj.root();
-      if (!rootPage) {
-        return undefined;
-      }
+      if (!rootPage) return undefined;
       return rootPage.get("intercomAppId");
     }).then((intercomAppId) => {
       if (intercomAppId) {
@@ -27,9 +25,7 @@ class Intercom extends React.Component {
   }
 
   render() {
-    if (!this.state.intercomAppId) {
-      return null;
-    }
+    if (!this.state.intercomAppId) return null;
 
     return (
       <Helmet>

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -33,9 +33,7 @@ function ActualNavigation({
 }
 
 function BackgroundVideo({ videoUrl }) {
-  if (!videoUrl) {
-    return null;
-  }
+  if (!videoUrl) return null;
 
   return (
     <video
@@ -94,9 +92,7 @@ class Navigation extends React.Component {
     } = currentPageNavigationOptions();
 
     const topSectionClassNames = ["navbar-fixed"];
-    if (this.state.scrolled) {
-      topSectionClassNames.push("scrolled");
-    }
+    if (this.state.scrolled) topSectionClassNames.push("scrolled");
 
     if (navigationStyle === "transparentDark") {
       topSectionClassNames.push("bg-dark-image");
@@ -105,17 +101,13 @@ class Navigation extends React.Component {
     }
 
     const bootstrapNavbarClassNames = [];
-    if (this.state.showSearch) {
-      bootstrapNavbarClassNames.push("show-search");
-    }
+    if (this.state.showSearch) bootstrapNavbarClassNames.push("show-search");
     if (navigationStyle === "transparentDark") {
       bootstrapNavbarClassNames.push("navbar-transparent");
     }
 
     let videoUrl = "";
-    if (isVideoObj(backgroundImage)) {
-      videoUrl = urlFromBinary(backgroundImage);
-    }
+    if (isVideoObj(backgroundImage)) videoUrl = urlFromBinary(backgroundImage);
 
     const topSectionStyle = {};
     if (navigationStyle === "transparentDark") {
@@ -152,9 +144,7 @@ class Navigation extends React.Component {
       }
     }
 
-    if (heightClassName) {
-      topSectionClassNames.push(heightClassName);
-    }
+    if (heightClassName) topSectionClassNames.push(heightClassName);
 
     return (
       <React.Fragment>

--- a/src/Components/Navigation/CollapseToggle.js
+++ b/src/Components/Navigation/CollapseToggle.js
@@ -2,9 +2,7 @@ import * as React from "react";
 
 function CollapseToggle({ expanded, toggleExpanded }) {
   const classNames = ["navbar-toggler"];
-  if (!expanded) {
-    classNames.push("collapsed");
-  }
+  if (!expanded) classNames.push("collapsed");
 
   return (
     <button

--- a/src/Components/Navigation/Logo.js
+++ b/src/Components/Navigation/Logo.js
@@ -12,17 +12,13 @@ function logoObj({ scrolled, navigationStyle }) {
   }
 
   const root = Scrivito.Obj.root();
-  if (root) {
-    return root.get(logoVersion);
-  }
+  if (root) return root.get(logoVersion);
 
   return undefined;
 }
 
 function Logo({ scrolled, navigationStyle }) {
-  if (!Scrivito.Obj.root()) {
-    return null;
-  }
+  if (!Scrivito.Obj.root()) return null;
 
   const logo = logoObj({ scrolled, navigationStyle });
 

--- a/src/Components/Navigation/NavChild.js
+++ b/src/Components/Navigation/NavChild.js
@@ -55,12 +55,8 @@ const NavChild = Scrivito.connect(BaseNavChild);
 
 const NavSingleChild = Scrivito.connect(({ child, open, ...otherProps }) => {
   const classNames = ["nav-item"];
-  if (open) {
-    classNames.push("open");
-  }
-  if (isActive(child)) {
-    classNames.push("active");
-  }
+  if (open) classNames.push("open");
+  if (isActive(child)) classNames.push("active");
 
   return (
     <li className={classNames.join(" ")} {...otherProps}>
@@ -74,12 +70,8 @@ const NavSingleChild = Scrivito.connect(({ child, open, ...otherProps }) => {
 const Dropdown = Scrivito.connect(
   ({ child, open, toggleDropdown, ...otherProps }) => {
     const classNames = ["nav-item"];
-    if (open) {
-      classNames.push("open");
-    }
-    if (isActive(child)) {
-      classNames.push("active");
-    }
+    if (open) classNames.push("open");
+    if (isActive(child)) classNames.push("active");
 
     return (
       <li className={classNames.join(" ")} {...otherProps}>
@@ -112,14 +104,10 @@ const Dropdown = Scrivito.connect(
 );
 
 function isActive(page) {
-  if (!Scrivito.currentPage()) {
-    return false;
-  }
+  if (!Scrivito.currentPage()) return false;
 
   const currentPath = Scrivito.currentPage().path();
-  if (currentPath) {
-    return currentPath.startsWith(page.path());
-  }
+  if (currentPath) return currentPath.startsWith(page.path());
 
   if (Scrivito.currentPage().objClass() === "BlogPost") {
     return page.objClass() === "Blog";

--- a/src/Components/Navigation/NavigationSection.js
+++ b/src/Components/Navigation/NavigationSection.js
@@ -2,17 +2,11 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 
 function NavigationSection({ heightClassName }) {
-  if (!["full-height", "medium-height"].includes(heightClassName)) {
-    return null;
-  }
+  if (!["full-height", "medium-height"].includes(heightClassName)) return null;
 
-  if (!Scrivito.currentPage()) {
-    return null;
-  }
+  if (!Scrivito.currentPage()) return null;
   const obj = Scrivito.currentPage();
-  if (!obj.get("navigationSection")) {
-    return null;
-  }
+  if (!obj.get("navigationSection")) return null;
 
   return (
     <Scrivito.ContentTag

--- a/src/Components/Navigation/ScrollToNextSectionLink.js
+++ b/src/Components/Navigation/ScrollToNextSectionLink.js
@@ -1,9 +1,7 @@
 import * as React from "react";
 
 function ScrollToNextSectionLink({ heightClassName }) {
-  if (heightClassName !== "full-height") {
-    return null;
-  }
+  if (heightClassName !== "full-height") return null;
 
   return (
     <a

--- a/src/Components/Navigation/Search.js
+++ b/src/Components/Navigation/Search.js
@@ -53,9 +53,7 @@ export const SearchBox = Scrivito.connect(
     }
 
     initFocus() {
-      if (this.props.showSearch) {
-        this.inputRef.current.focus();
-      }
+      if (this.props.showSearch) this.inputRef.current.focus();
     }
 
     onChange(event) {

--- a/src/Components/Navigation/currentPageNavigationOptions.js
+++ b/src/Components/Navigation/currentPageNavigationOptions.js
@@ -43,9 +43,7 @@ function blogPostNavigationOptions(obj) {
   let backgroundImage = obj.get("titleImage");
   if (!backgroundImage) {
     const blog = Scrivito.Obj.getByPermalink("blog");
-    if (blog) {
-      backgroundImage = blog.get("navigationBackgroundImage");
-    }
+    if (blog) backgroundImage = blog.get("navigationBackgroundImage");
   }
 
   return imageWithMediumHeightOrMinHeight(backgroundImage);
@@ -82,9 +80,7 @@ function pageNavigationOptions(obj) {
 
   const navigationHeight = obj.get("navigationHeight") || "small";
   let heightClassName = null;
-  if (navigationHeight !== "small") {
-    heightClassName = navigationHeight;
-  }
+  if (navigationHeight !== "small") heightClassName = navigationHeight;
 
   let navigationStyle = "solidWhite";
   if (backgroundImage || navigationHeight !== "small") {

--- a/src/Components/SchemaDotOrg.js
+++ b/src/Components/SchemaDotOrg.js
@@ -50,9 +50,7 @@ function dataFromItem(item) {
 
 function pruneEmptyValues(data) {
   let prunedData = mapValues(data, (subData) => {
-    if (isPlainObject(subData)) {
-      return pruneEmptyValues(subData);
-    }
+    if (isPlainObject(subData)) return pruneEmptyValues(subData);
     return subData;
   });
 
@@ -61,9 +59,7 @@ function pruneEmptyValues(data) {
   const keysWithoutAt = Object.keys(prunedData).filter(
     (sd) => !sd.startsWith("@")
   );
-  if (keysWithoutAt.length) {
-    return prunedData;
-  }
+  if (keysWithoutAt.length) return prunedData;
   return {};
 }
 

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -31,9 +31,7 @@ const ColumnsEditor = Scrivito.connect(({ widget, readOnly, currentGrid }) => {
       <Alignment
         alignment={widget.get("alignment")}
         setAlignment={(alignment) => {
-          if (!readOnly) {
-            widget.update({ alignment });
-          }
+          if (!readOnly) widget.update({ alignment });
         }}
         readOnly={readOnly}
       />
@@ -149,12 +147,8 @@ const ColumnsEditor = Scrivito.connect(({ widget, readOnly, currentGrid }) => {
   );
 
   function adjustGrid(newGrid) {
-    if (readOnly) {
-      return;
-    }
-    if (isEqual(currentGrid, newGrid)) {
-      return;
-    }
+    if (readOnly) return;
+    if (isEqual(currentGrid, newGrid)) return;
 
     adjustNumberOfColumns(widget, newGrid.length);
     distributeContents(widget.get("columns"), originalContents);
@@ -172,10 +166,7 @@ function calculateContentIds(contents) {
 
 function PresetGrid({ currentGrid, adjustGrid, title, grid, readOnly }) {
   const classNames = readOnly ? ["gle-preview"] : ["gle-preview", "clickable"];
-
-  if (isEqual(currentGrid, grid)) {
-    classNames.push("active");
-  }
+  if (isEqual(currentGrid, grid)) classNames.push("active");
 
   return (
     <div
@@ -302,16 +293,12 @@ class GridLayoutEditor extends React.Component {
       this.gridRulerRef.current.firstChild.getBoundingClientRect().width + 10;
 
     if (this.state.draggableGrid !== draggableGrid) {
-      this.setState({
-        draggableGrid,
-      });
+      this.setState({ draggableGrid });
     }
   }
 
   onDragStop({ colIndex, deltaColSize }) {
-    if (deltaColSize === 0) {
-      return;
-    }
+    if (deltaColSize === 0) return;
 
     const newGrid = [...this.props.currentGrid];
     newGrid[colIndex] += deltaColSize;
@@ -321,9 +308,7 @@ class GridLayoutEditor extends React.Component {
   }
 
   adjustNumberOfColumns(wantedCols) {
-    if (wantedCols > 6 || wantedCols < 1) {
-      return;
-    }
+    if (wantedCols > 6 || wantedCols < 1) return;
 
     if (wantedCols === 5) {
       this.props.adjustGrid([2, 2, 2, 2, 4]);
@@ -427,9 +412,7 @@ function gridOfWidget(containerWidget) {
 
 function adjustNumberOfColumns(containerWidget, desiredLength) {
   const columns = containerWidget.get("columns");
-  if (columns.length === desiredLength) {
-    return;
-  }
+  if (columns.length === desiredLength) return;
 
   const newColumns = times(desiredLength).map(
     (index) => columns[index] || new ColumnWidget({})
@@ -462,9 +445,7 @@ function adjustColSize(columns, newGrid) {
 }
 
 function AlignmentDescription({ alignment }) {
-  if (alignment !== "stretch") {
-    return null;
-  }
+  if (alignment !== "stretch") return null;
 
   return (
     <div className="scrivito_notice_body">

--- a/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
@@ -9,9 +9,7 @@ function AllIcons({ setWidgetIcon, currentIcon, hide }) {
     const result = {};
     fontAwesomeIcons.forEach((icon) =>
       icon.categories.forEach((category) => {
-        if (!result[category]) {
-          result[category] = [];
-        }
+        if (!result[category]) result[category] = [];
         result[category].push(icon);
       })
     );
@@ -22,9 +20,7 @@ function AllIcons({ setWidgetIcon, currentIcon, hide }) {
     setTimeout(() => setInitialRender(false), 10);
   }, []);
 
-  if (hide) {
-    return null;
-  }
+  if (hide) return null;
 
   return (
     <React.Fragment>
@@ -88,9 +84,7 @@ function Category({ category, icons, currentIcon, setWidgetIcon }) {
           const cssIcon = `fa-${icon.id}`;
 
           const aClassNames = [];
-          if (currentIcon === cssIcon) {
-            aClassNames.push("active");
-          }
+          if (currentIcon === cssIcon) aClassNames.push("active");
 
           // Note: It is up to 10% faster to inline the SingleIcon component,
           // instead of creating one SingleIcon component for each of the 675 icons.

--- a/src/Components/ScrivitoExtensions/IconEditorTab/IconSearch.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/IconSearch.js
@@ -33,9 +33,7 @@ function IconSearch({ setSearchValue, searchValue }) {
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
 function ClearSearchButton({ setSearchValue, searchValue }) {
-  if (!searchValue.length) {
-    return null;
-  }
+  if (!searchValue.length) return null;
 
   return (
     <a

--- a/src/Components/ScrivitoExtensions/IconEditorTab/IconSearchResults.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/IconSearchResults.js
@@ -13,9 +13,7 @@ function IconSearchResults({ searchValue, setWidgetIcon, currentIcon }) {
     return new Fuse(fontAwesomeIcons, fuseOptions);
   }, []);
 
-  if (!searchValue.length) {
-    return null;
-  }
+  if (!searchValue.length) return null;
 
   const results = fuse.search(searchValue);
 

--- a/src/Components/ScrivitoExtensions/IconEditorTab/SingleIcon.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/SingleIcon.js
@@ -6,9 +6,7 @@ function SingleIcon({ icon, setWidgetIcon, currentIcon }) {
   const cssIcon = `fa-${icon.id}`;
 
   const aClassNames = [];
-  if (currentIcon === cssIcon) {
-    aClassNames.push("active");
-  }
+  if (currentIcon === cssIcon) aClassNames.push("active");
 
   return (
     <div className="fa-hover col-md-3 col-sm-4">

--- a/src/Components/ScrivitoExtensions/SocialCardsTab.js
+++ b/src/Components/ScrivitoExtensions/SocialCardsTab.js
@@ -5,9 +5,7 @@ import getMetadata from "../../utils/getMetadata";
 
 function SocialCardsTab({ obj }) {
   const uiContext = Scrivito.uiContext();
-  if (uiContext === undefined) {
-    return null;
-  }
+  if (uiContext === undefined) return null;
 
   return (
     <div className={`scrivito_${uiContext.theme}`}>
@@ -138,9 +136,7 @@ const FacebookPreview = Scrivito.connect(({ obj }) => (
 ));
 
 function OptionalImage({ src }) {
-  if (!src) {
-    return null;
-  }
+  if (!src) return null;
 
   return <img src={src} alt="seo-card-preview-img" />;
 }
@@ -150,16 +146,12 @@ function lookupMetadata(obj, value) {
 
   if (value.includes("og:")) {
     const ogData = metadata.find((x) => x.property === value);
-    if (ogData) {
-      return ogData.content;
-    }
+    if (ogData) return ogData.content;
   }
 
   if (value.includes("twitter:")) {
     const twitterData = metadata.find((x) => x.name === value);
-    if (twitterData) {
-      return twitterData.content;
-    }
+    if (twitterData) return twitterData.content;
   }
 
   return "";

--- a/src/Components/TagList.js
+++ b/src/Components/TagList.js
@@ -2,9 +2,7 @@ import * as React from "react";
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
 function TagList({ showTags, tags, currentTag, setTag }) {
-  if (!showTags) {
-    return null;
-  }
+  if (!showTags) return null;
 
   const onClick = (e, tag) => {
     e.preventDefault();

--- a/src/Components/Tracking.js
+++ b/src/Components/Tracking.js
@@ -25,9 +25,7 @@ export default function Tracking() {
 function configureGoogleAnalytics() {
   return Scrivito.load(() => {
     const rootPage = Scrivito.Obj.root();
-    if (!rootPage) {
-      return undefined;
-    }
+    if (!rootPage) return undefined;
     return rootPage.get("googleAnalyticsTrackingId");
   }).then((trackingId) => {
     if (trackingId) {

--- a/src/Objs/Job/JobComponent.js
+++ b/src/Objs/Job/JobComponent.js
@@ -34,9 +34,7 @@ Scrivito.provideComponent("Job", ({ page }) => (
 const JobDatePosted = Scrivito.connect(({ page }) => {
   const datePosted = page.get("datePosted");
 
-  if (!datePosted && !Scrivito.isInPlaceEditingActive()) {
-    return null;
-  }
+  if (!datePosted && !Scrivito.isInPlaceEditingActive()) return null;
 
   return (
     <Scrivito.ContentTag content={page} attribute="datePosted" tag="span">
@@ -54,9 +52,7 @@ const JobDatePosted = Scrivito.connect(({ page }) => {
 const JobValidThrough = Scrivito.connect(({ page }) => {
   const validThrough = page.get("validThrough");
 
-  if (!validThrough && !Scrivito.isInPlaceEditingActive()) {
-    return null;
-  }
+  if (!validThrough && !Scrivito.isInPlaceEditingActive()) return null;
 
   return (
     <h2 className="h5">

--- a/src/Objs/Redirect/RedirectComponent.js
+++ b/src/Objs/Redirect/RedirectComponent.js
@@ -10,9 +10,7 @@ class RedirectComponent extends React.Component {
 
       return { link, url };
     }).then(({ link, url }) => {
-      if (!link) {
-        return;
-      }
+      if (!link) return;
 
       if (link.isExternal()) {
         window.top.location.replace(url);

--- a/src/Objs/SearchResults/SearchResultItem.js
+++ b/src/Objs/SearchResults/SearchResultItem.js
@@ -12,9 +12,8 @@ const PreviewImage = Scrivito.connect(({ item }) => {
     item.get("navigationBackgroundImage") ||
     item.get("titleImage") ||
     item.get("image");
-  if (!image || isVideoObj(image)) {
-    return null;
-  }
+  if (!image || isVideoObj(image)) return null;
+
   return (
     <Scrivito.LinkTag to={item} className="search-result-item--image">
       <Scrivito.ImageTag content={image} alt={image.get("alternativeText")} />
@@ -26,23 +25,15 @@ const Details = Scrivito.connect(({ item }) => {
   const details = [];
 
   const date = item.get("publishedAt") || item.lastChanged();
-  if (date) {
-    details.push(fromNow(date));
-  }
+  if (date) details.push(fromNow(date));
 
   const author = item.get("author");
-  if (author) {
-    details.push(`by ${author.get("title")}`);
-  }
+  if (author) details.push(`by ${author.get("title")}`);
 
   const tags = item.get("tags");
-  if (tags && tags.length) {
-    details.push(`tags: ${tags.join(", ")}`);
-  }
+  if (tags && tags.length) details.push(`tags: ${tags.join(", ")}`);
 
-  if (!details.length) {
-    return null;
-  }
+  if (!details.length) return null;
 
   return <small>{details.join(" // ")}</small>;
 });

--- a/src/Objs/SearchResults/SearchResultsTagList.js
+++ b/src/Objs/SearchResults/SearchResultsTagList.js
@@ -9,9 +9,7 @@ function SearchResultsTagList({ tags, params }) {
       showTags={tags.length}
       setTag={(newTag) => {
         const newParams = { q: params.q };
-        if (newTag) {
-          newParams.tag = newTag;
-        }
+        if (newTag) newParams.tag = newTag;
 
         Scrivito.navigateTo(() => Scrivito.currentPage(), newParams);
       }}

--- a/src/Objs/SearchResults/ShowMoreButton.js
+++ b/src/Objs/SearchResults/ShowMoreButton.js
@@ -2,9 +2,7 @@ import * as React from "react";
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
 function ShowMoreButton({ currentMaxItems, totalCount, onClick }) {
-  if (currentMaxItems >= totalCount) {
-    return null;
-  }
+  if (currentMaxItems >= totalCount) return null;
 
   return (
     <React.Fragment>

--- a/src/Widgets/AddressWidget/AddressWidgetComponent.js
+++ b/src/Widgets/AddressWidget/AddressWidgetComponent.js
@@ -21,14 +21,10 @@ Scrivito.provideComponent("AddressWidget", ({ widget }) => (
 
 const Logo = Scrivito.connect(() => {
   const root = Scrivito.Obj.root();
-  if (!root) {
-    return null;
-  }
+  if (!root) return null;
 
   const logo = root.get("logoDark");
-  if (!logo) {
-    return null;
-  }
+  if (!logo) return null;
 
   return (
     <Scrivito.LinkTag to={root}>
@@ -83,10 +79,7 @@ const Address = Scrivito.connect(({ addressWidget }) => {
 
 function Table(props) {
   const lines = Object.entries(props).filter(([_prop, value]) => value);
-
-  if (!lines.length) {
-    return null;
-  }
+  if (!lines.length) return null;
 
   return (
     <table>

--- a/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
+++ b/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
@@ -6,9 +6,7 @@ Scrivito.provideComponent("BlogOverviewWidget", ({ widget }) => {
   let { tag } = Scrivito.currentPageParams();
 
   const tags = widget.get("tags");
-  if (!tag && tags.length) {
-    tag = tags;
-  }
+  if (!tag && tags.length) tag = tags;
 
   return (
     <BlogPostPreviewList

--- a/src/Widgets/BoxWidget/BoxWidgetComponent.js
+++ b/src/Widgets/BoxWidget/BoxWidgetComponent.js
@@ -3,12 +3,8 @@ import * as Scrivito from "scrivito";
 
 Scrivito.provideComponent("BoxWidget", ({ widget }) => {
   const classNames = ["card"];
-  if (widget.get("boxStyle") !== "white") {
-    classNames.push("card-theme");
-  }
-  if (widget.get("useOffset")) {
-    classNames.push("box-offset");
-  }
+  if (widget.get("boxStyle") !== "white") classNames.push("card-theme");
+  if (widget.get("useOffset")) classNames.push("box-offset");
 
   return (
     <Scrivito.WidgetTag className={classNames.join(" ")}>

--- a/src/Widgets/ButtonWidget/ButtonWidgetComponent.js
+++ b/src/Widgets/ButtonWidget/ButtonWidgetComponent.js
@@ -19,9 +19,7 @@ Scrivito.provideComponent("ButtonWidget", ({ widget }) => {
   classNames.push(widget.get("style") || "btn-primary");
 
   const alignment = widget.get("alignment");
-  if (alignment === "block") {
-    classNames.push("btn-block");
-  }
+  if (alignment === "block") classNames.push("btn-block");
 
   return (
     <WrapIfClassName className={alignmentClassName(alignment)}>

--- a/src/Widgets/CarouselWidget/CarouselWidgetComponent.js
+++ b/src/Widgets/CarouselWidget/CarouselWidgetComponent.js
@@ -34,9 +34,7 @@ Scrivito.provideComponent("CarouselWidget", ({ widget }) => {
 });
 
 const DescriptionBox = Scrivito.connect(({ widget }) => {
-  if (!widget.get("showDescription")) {
-    return null;
-  }
+  if (!widget.get("showDescription")) return null;
 
   return (
     <div className="container">

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
@@ -68,9 +68,7 @@ function StaticGoogleMap({ address, apiKey, zoom, children }) {
 }
 
 function scaleMapSize(width, height) {
-  if (!width || !height || width <= maxWidth) {
-    return { width, height };
-  }
+  if (!width || !height || width <= maxWidth) return { width, height };
 
   const factor = height / width;
   const adjustedHeight = Math.round(maxWidth * factor);
@@ -93,17 +91,13 @@ function getMapUrl({ width, height, address, apiKey, zoom }) {
     ie: "UTF8",
   };
 
-  if (apiKey) {
-    params.key = apiKey;
-  }
+  if (apiKey) params.key = apiKey;
 
   return googleMapsImageUrl(params);
 }
 
 const Widgets = Scrivito.connect(({ widget, mapType }) => {
-  if (!widget.get("showWidgets")) {
-    return null;
-  }
+  if (!widget.get("showWidgets")) return null;
 
   const containerClasses = ["container", "container-initial"];
   if (mapType === "interactive") {

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
@@ -10,16 +10,10 @@ Scrivito.provideComponent("HeadlineWidget", ({ widget }) => {
   const classNames = ["headline-widget", style];
 
   const alignment = alignmentClassName(widget.get("alignment"));
-  if (alignment) {
-    classNames.push(alignment);
-  }
+  if (alignment) classNames.push(alignment);
 
-  if (widget.get("showDividingLine")) {
-    classNames.push("b-bottom");
-  }
-  if (!widget.get("showMargin")) {
-    classNames.push("no-margin");
-  }
+  if (widget.get("showDividingLine")) classNames.push("b-bottom");
+  if (!widget.get("showMargin")) classNames.push("no-margin");
 
   return (
     <>

--- a/src/Widgets/IconWidget/IconWidgetEditingConfig.js
+++ b/src/Widgets/IconWidget/IconWidgetEditingConfig.js
@@ -51,9 +51,6 @@ Scrivito.provideEditingConfig("IconWidget", {
   },
   titleForContent: (widget) => {
     const iconText = widget.get("icon").replace(/^fa-/, "");
-
-    if (iconText) {
-      return `Icon: ${iconText}`;
-    }
+    if (iconText) return `Icon: ${iconText}`;
   },
 });

--- a/src/Widgets/ImageWidget/ImageWidgetComponent.js
+++ b/src/Widgets/ImageWidget/ImageWidgetComponent.js
@@ -26,14 +26,10 @@ Scrivito.provideComponent("ImageWidget", ({ widget }) => {
 
 function alternativeText(widget) {
   const widgetAlternativeText = widget.get("alternativeText");
-  if (widgetAlternativeText) {
-    return widgetAlternativeText;
-  }
+  if (widgetAlternativeText) return widgetAlternativeText;
 
   const image = widget.get("image");
-  if (image) {
-    return image.get("alternativeText");
-  }
+  if (image) return image.get("alternativeText");
 
   return "";
 }

--- a/src/Widgets/LinkWidget/LinkWidgetComponent.js
+++ b/src/Widgets/LinkWidget/LinkWidgetComponent.js
@@ -25,13 +25,8 @@ Scrivito.provideComponent("LinkWidget", ({ widget }) => {
 });
 
 const LinkTitle = Scrivito.connect(({ link }) => {
-  if (link.title()) {
-    return link.title();
-  }
-
-  if (link.isInternal()) {
-    return link.obj().get("title");
-  }
+  if (link.title()) return link.title();
+  if (link.isInternal()) return link.obj().get("title");
 
   return link.url();
 });

--- a/src/Widgets/SectionWidget/SectionWidgetComponent.js
+++ b/src/Widgets/SectionWidget/SectionWidgetComponent.js
@@ -20,18 +20,12 @@ Scrivito.provideComponent("SectionWidget", ({ widget }) => {
 
   sectionClassNames.push(`bg-${backgroundColor}`);
 
-  if (!widget.get("showPadding")) {
-    sectionClassNames.push("no-padding");
-  }
+  if (!widget.get("showPadding")) sectionClassNames.push("no-padding");
 
   let contentClassName = "container";
-  if (widget.get("useFullWidth")) {
-    contentClassName = "container-fluid gutter0";
-  }
+  if (widget.get("useFullWidth")) contentClassName = "container-fluid gutter0";
 
-  if (widget.get("useFullHeight")) {
-    sectionClassNames.push("full-height");
-  }
+  if (widget.get("useFullHeight")) sectionClassNames.push("full-height");
 
   return (
     <Scrivito.BackgroundImageTag

--- a/src/Widgets/TableWidget/TableWidgetComponent.js
+++ b/src/Widgets/TableWidget/TableWidgetComponent.js
@@ -55,14 +55,10 @@ Scrivito.provideComponent("TableWidget", ({ widget }) => (
 /* eslint-disable jsx-a11y/anchor-is-valid */
 const AddMoreRows = Scrivito.connect(
   ({ widget, title, attribute, maxRows }) => {
-    if (!Scrivito.isInPlaceEditingActive()) {
-      return null;
-    }
+    if (!Scrivito.isInPlaceEditingActive()) return null;
 
     const currentRows = widget.get(attribute);
-    if (maxRows && currentRows.length >= maxRows) {
-      return null;
-    }
+    if (maxRows && currentRows.length >= maxRows) return null;
 
     return (
       <tr>

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
@@ -82,9 +82,7 @@ const fallbackImageUrl =
   "testimonial_slider_widget_fallback_author.jpeg";
 
 const AddTestimonial = ({ widget }) => {
-  if (!Scrivito.isInPlaceEditingActive()) {
-    return null;
-  }
+  if (!Scrivito.isInPlaceEditingActive()) return null;
 
   return (
     <div className="text-center">

--- a/src/Widgets/TestimonialWidget/TestimonialWidgetEditingConfig.js
+++ b/src/Widgets/TestimonialWidget/TestimonialWidgetEditingConfig.js
@@ -52,8 +52,6 @@ Scrivito.provideEditingConfig("TestimonialWidget", {
     const parts = [widget.get("author"), truncate(widget.get("testimonial"))];
     const summary = parts.filter((e) => e).join(" - ");
 
-    if (summary) {
-      return `Testimonial: ${summary}`;
-    }
+    if (summary) return `Testimonial: ${summary}`;
   },
 });

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -110,9 +110,7 @@ const Thumbnail = Scrivito.connect(({ widget, openLightbox, currentTag }) => {
     "gutter0",
     "thumbnail-gallery-widget",
   ];
-  if (currentTag && !tags.includes(currentTag)) {
-    classNames.push("squeezed");
-  }
+  if (currentTag && !tags.includes(currentTag)) classNames.push("squeezed");
 
   return (
     <div className={classNames.join(" ")}>

--- a/src/config/scrivito.js
+++ b/src/config/scrivito.js
@@ -9,17 +9,13 @@ export function configureScrivito(options) {
     tenant: process.env.SCRIVITO_TENANT,
   };
 
-  if (process.env.SCRIVITO_ORIGIN) {
-    config.origin = process.env.SCRIVITO_ORIGIN;
-  }
+  if (process.env.SCRIVITO_ORIGIN) config.origin = process.env.SCRIVITO_ORIGIN;
 
   if (process.env.SCRIVITO_ENDPOINT) {
     config.endpoint = process.env.SCRIVITO_ENDPOINT;
   }
 
-  if (options?.priority) {
-    config.priority = options.priority;
-  }
+  if (options?.priority) config.priority = options.priority;
 
   Scrivito.configure(config);
 }

--- a/src/prerenderContent/filenameFromUrl.js
+++ b/src/prerenderContent/filenameFromUrl.js
@@ -1,8 +1,6 @@
 export default function filenameFromUrl(url) {
   const { pathname } = new URL(url);
-  if (pathname === "/") {
-    return "/index.html";
-  }
+  if (pathname === "/") return "/index.html";
 
   return `${pathname}.html`;
 }

--- a/src/prerenderContent/prerenderObjs.js
+++ b/src/prerenderContent/prerenderObjs.js
@@ -20,9 +20,7 @@ export default async function prerenderObjs(
   const files = [];
   const storeFile = async (file) => {
     const storedFile = await storeResult(targetDir, file);
-    if (storedFile) {
-      files.push(storedFile);
-    }
+    if (storedFile) files.push(storedFile);
   };
 
   const objsGroups = chunk(objs, 10);
@@ -45,9 +43,7 @@ export default async function prerenderObjs(
   );
 
   console.timeEnd("[prerenderObjs]");
-  if (failedCount) {
-    reportError(`Skipped ${failedCount} objs due to failures.`);
-  }
+  if (failedCount) reportError(`Skipped ${failedCount} objs due to failures.`);
 
   return files;
 }

--- a/src/utils/alignmentClassName.js
+++ b/src/utils/alignmentClassName.js
@@ -1,11 +1,6 @@
 export function alignmentClassName(widgetAlignment) {
-  if (widgetAlignment === "center") {
-    return "text-center";
-  }
-
-  if (widgetAlignment === "right") {
-    return "text-end";
-  }
+  if (widgetAlignment === "center") return "text-center";
+  if (widgetAlignment === "right") return "text-end";
 
   return null;
 }

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -2,9 +2,7 @@ import dateFormat from "dateformat";
 
 function formatDate(date, format) {
   // dateFormat uses Date.now if no date is given.
-  if (!date) {
-    return null;
-  }
+  if (!date) return null;
 
   return dateFormat(date, format);
 }

--- a/src/utils/fullScreenWidthPixels.js
+++ b/src/utils/fullScreenWidthPixels.js
@@ -7,9 +7,7 @@ import devicePixelRatio from "./devicePixelRatio";
 const SSR_FALLBACK_WIDTH_PX = 945;
 
 function fullScreenWidthPixels() {
-  if (typeof window === "undefined") {
-    return SSR_FALLBACK_WIDTH_PX;
-  }
+  if (typeof window === "undefined") return SSR_FALLBACK_WIDTH_PX;
 
   const screenWidth = window.screen.width;
 

--- a/src/utils/getMetadata.js
+++ b/src/utils/getMetadata.js
@@ -17,9 +17,7 @@ function getMetadata(page) {
   }
 
   const description = page.get("metaDataDescription");
-  if (description) {
-    meta.push({ name: "description", content: description });
-  }
+  if (description) meta.push({ name: "description", content: description });
 
   const root = Scrivito.Obj.root();
   if (root) {
@@ -29,15 +27,11 @@ function getMetadata(page) {
     }
 
     const twitterSite = root.get("twitterSite");
-    if (twitterSite) {
-      meta.push({ name: "twitter:site", content: twitterSite });
-    }
+    if (twitterSite) meta.push({ name: "twitter:site", content: twitterSite });
   }
 
   const tcCreator = page.get("tcCreator");
-  if (tcCreator) {
-    meta.push({ name: "twitter:creator", content: tcCreator });
-  }
+  if (tcCreator) meta.push({ name: "twitter:creator", content: tcCreator });
 
   const tcDescription =
     page.get("tcDescription") ||
@@ -53,14 +47,10 @@ function getMetadata(page) {
     "image",
   ]);
 
-  if (tcImage) {
-    meta.push({ name: "twitter:image", content: tcImage });
-  }
+  if (tcImage) meta.push({ name: "twitter:image", content: tcImage });
 
   const tcTitle = page.get("tcTitle") || page.get("title");
-  if (tcTitle) {
-    meta.push({ name: "twitter:title", content: tcTitle });
-  }
+  if (tcTitle) meta.push({ name: "twitter:title", content: tcTitle });
 
   const ogDescription =
     page.get("ogDescription") ||
@@ -76,14 +66,10 @@ function getMetadata(page) {
     "image",
   ]);
 
-  if (ogImage) {
-    meta.push({ property: "og:image", content: ogImage });
-  }
+  if (ogImage) meta.push({ property: "og:image", content: ogImage });
 
   const ogTitle = page.get("ogTitle") || page.get("title");
-  if (ogTitle) {
-    meta.push({ property: "og:title", content: ogTitle });
-  }
+  if (ogTitle) meta.push({ property: "og:title", content: ogTitle });
 
   return meta;
 }
@@ -92,13 +78,11 @@ function firstImageUrlForAttributes(obj, attributes) {
   let url;
 
   attributes.forEach((attribute) => {
-    if (url) {
-      return;
-    }
+    if (url) return;
+
     const binary = obj.get(attribute);
-    if (isVideoObj(binary)) {
-      return;
-    }
+    if (isVideoObj(binary)) return;
+
     url = urlFromBinary(binary);
   });
 

--- a/src/utils/googleMapsApiKey.js
+++ b/src/utils/googleMapsApiKey.js
@@ -2,9 +2,7 @@ import * as Scrivito from "scrivito";
 
 function googleMapsApiKey() {
   const root = Scrivito.Obj.root();
-  if (!root) {
-    return "";
-  }
+  if (!root) return "";
 
   return root.get("googleMapsApiKey");
 }

--- a/src/utils/googleMapsImageUrl.js
+++ b/src/utils/googleMapsImageUrl.js
@@ -115,18 +115,12 @@ function toColor(value) {
 }
 
 function computeTag(featureType, elementType) {
-  if (!featureType && !elementType) {
-    return "feature:all";
-  }
+  if (!featureType && !elementType) return "feature:all";
 
   const target = [];
 
-  if (featureType) {
-    target.push(`feature:${featureType}`);
-  }
-  if (elementType) {
-    target.push(`element:${elementType}`);
-  }
+  if (featureType) target.push(`feature:${featureType}`);
+  if (elementType) target.push(`element:${elementType}`);
 
   return target.join(separator);
 }

--- a/src/utils/isVideoObj.js
+++ b/src/utils/isVideoObj.js
@@ -1,12 +1,8 @@
 function isVideoObj(obj) {
-  if (!obj) {
-    return false;
-  }
+  if (!obj) return false;
 
   const contentType = obj.contentType();
-  if (!contentType) {
-    return false;
-  }
+  if (!contentType) return false;
 
   return contentType.startsWith("video/");
 }

--- a/src/utils/navigateToBlogWithTag.js
+++ b/src/utils/navigateToBlogWithTag.js
@@ -2,9 +2,7 @@ import * as Scrivito from "scrivito";
 
 function navigateToBlogWithTag(tag) {
   const params = {};
-  if (tag) {
-    params.tag = tag;
-  }
+  if (tag) params.tag = tag;
 
   Scrivito.navigateTo(() => Scrivito.Obj.getByPermalink("blog"), params);
 }

--- a/src/utils/urlFromBinary.js
+++ b/src/utils/urlFromBinary.js
@@ -1,12 +1,8 @@
 function urlFromBinary(binary) {
-  if (!binary) {
-    return null;
-  }
+  if (!binary) return null;
 
   const blob = binary.get("blob");
-  if (!blob) {
-    return null;
-  }
+  if (!blob) return null;
 
   return blob.url() || null;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,9 +16,7 @@ dotenv.config();
 
 // Extend headersCsp with custom endpoint URL
 const endpoint = process.env.SCRIVITO_ENDPOINT;
-if (endpoint) {
-  headersCsp["script-src"].push(`https://${endpoint}`);
-}
+if (endpoint) headersCsp["script-src"].push(`https://${endpoint}`);
 
 const BUILD_DIR = "build";
 


### PR DESCRIPTION
The eslint rule `curly` allows "single line if statements" with the "multi-line" option (see https://eslint.org/docs/rules/curly#multi-line for more details).

It basically allows to write a statement like this:

```js
  if (preconditionNotMet) return null;
```

Previously one had to split this statement up into multiple lines:
```js
  if (preconditionNotMet) {
    return null;
  }
```