### PR TITLE
Set Webpack optimization `runtimeChunk` to `single`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,9 @@ function webpackConfig(env = {}) {
       scrivito_extensions: "./scrivito_extensions.js",
     },
     target: "web",
+    optimization: {
+      runtimeChunk: "single",
+    },
     module: {
       rules: [
         {


### PR DESCRIPTION
This seems to fix a weird behavior on some dev boxes: When files are changed, the app does not get properly reloaded.
See also https://webpack.js.org/configuration/optimization/#optimizationruntimechunk