### PR TITLE
Convert default exports to named exports.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
     "btoa": true
   },
   "rules": {
+    "prefer-arrow-callback": [2, { "allowNamedFunctions": true }],
     "class-methods-use-this": [
       2,
       {

--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,9 @@ export default function App() {
             <div className="content-wrapper">
               <Navigation />
               <Scrivito.CurrentPage />
-              <NotFoundErrorPage />
+              <Scrivito.NotFoundErrorPage>
+                <NotFoundErrorPage />
+              </Scrivito.NotFoundErrorPage>
             </div>
             <Footer />
             <CurrentPageMetadata />

--- a/src/App.js
+++ b/src/App.js
@@ -2,19 +2,19 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 import { HelmetProvider } from "react-helmet-async";
 
-import CurrentPageMetadata from "./Components/CurrentPageMetadata";
-import ErrorBoundary from "./Components/ErrorBoundary";
-import Footer from "./Components/Footer";
-import Intercom from "./Components/Intercom";
-import Navigation from "./Components/Navigation";
-import NotFoundErrorPage from "./Components/NotFoundErrorPage";
-import CookieConsentBanner from "./Components/CookieConsentBanner";
-import Tracking from "./Components/Tracking";
+import { CurrentPageMetadata } from "./Components/CurrentPageMetadata";
+import { ErrorBoundary } from "./Components/ErrorBoundary";
+import { Footer } from "./Components/Footer";
+import { Intercom } from "./Components/Intercom";
+import { Navigation } from "./Components/Navigation";
+import { NotFoundErrorPage } from "./Components/NotFoundErrorPage";
+import { CookieConsentBanner } from "./Components/CookieConsentBanner";
+import { Tracking } from "./Components/Tracking";
 import { CookieConsentProvider } from "./Components/CookieConsentContext";
 
 export const helmetContext = {};
 
-export default function App() {
+export function App() {
   return (
     <ErrorBoundary>
       <CookieConsentProvider>

--- a/src/Components/AnimateOnReveal.js
+++ b/src/Components/AnimateOnReveal.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import Zoom from "react-reveal-iframe/Zoom";
 import Fade from "react-reveal-iframe/Fade";
 
-function AnimateOnReveal({ animation, children }) {
+export function AnimateOnReveal({ animation, children }) {
   switch (animation) {
     case "zoomIn":
       return <Zoom>{children}</Zoom>;
@@ -18,5 +18,3 @@ function AnimateOnReveal({ animation, children }) {
       return children;
   }
 }
-
-export default AnimateOnReveal;

--- a/src/Components/AuthorImage.js
+++ b/src/Components/AuthorImage.js
@@ -1,9 +1,9 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "./InPlaceEditingPlaceholder";
-import isImage from "../utils/isImage";
+import { InPlaceEditingPlaceholder } from "./InPlaceEditingPlaceholder";
+import { isImage } from "../utils/isImage";
 
-function AuthorImage({ image }) {
+export const AuthorImage = Scrivito.connect(function AuthorImage({ image }) {
   if (!isImage(image)) {
     return (
       <InPlaceEditingPlaceholder center>
@@ -24,6 +24,4 @@ function AuthorImage({ image }) {
       }}
     />
   );
-}
-
-export default Scrivito.connect(AuthorImage);
+});

--- a/src/Components/BlogPost/BlogPostAuthor.js
+++ b/src/Components/BlogPost/BlogPostAuthor.js
@@ -1,9 +1,11 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import AuthorImage from "../AuthorImage";
-import isImage from "../../utils/isImage";
+import { AuthorImage } from "../AuthorImage";
+import { isImage } from "../../utils/isImage";
 
-function BlogPostAuthor({ author }) {
+export const BlogPostAuthor = Scrivito.connect(function BlogPostAuthor({
+  author,
+}) {
   if (!author) return null;
   if (author.objClass() !== "Author") return null;
 
@@ -17,7 +19,7 @@ function BlogPostAuthor({ author }) {
       </div>
     </section>
   );
-}
+});
 
 const AuthorImageAndDescription = Scrivito.connect(({ author }) => {
   if (!isImage(author.get("image"))) {
@@ -50,5 +52,3 @@ const AuthorDescription = Scrivito.connect(({ author }) => (
     <p>{author.get("description")}</p>
   </React.Fragment>
 ));
-
-export default Scrivito.connect(BlogPostAuthor);

--- a/src/Components/BlogPost/BlogPostDate.js
+++ b/src/Components/BlogPost/BlogPostDate.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import formatDate from "../../utils/formatDate";
+import { formatDate } from "../../utils/formatDate";
 
-function BlogPostDate({ post }) {
+export const BlogPostDate = Scrivito.connect(function BlogPostDate({ post }) {
   const date = post.get("publishedAt");
   if (!date) return null;
 
@@ -17,6 +17,4 @@ function BlogPostDate({ post }) {
       {formatDate(date, "mm/dd")}
     </Scrivito.ContentTag>
   );
-}
-
-export default Scrivito.connect(BlogPostDate);
+});

--- a/src/Components/BlogPost/BlogPostMorePosts.js
+++ b/src/Components/BlogPost/BlogPostMorePosts.js
@@ -1,8 +1,11 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import BlogPostPreviewList from "./BlogPostPreviewList";
+import { BlogPostPreviewList } from "./BlogPostPreviewList";
 
-function BlogPostMorePosts({ author, filterBlogPostId }) {
+export const BlogPostMorePosts = Scrivito.connect(function BlogPostMorePosts({
+  author,
+  filterBlogPostId,
+}) {
   if (!author) return null;
   if (author.objClass() !== "Author") return null;
 
@@ -19,6 +22,4 @@ function BlogPostMorePosts({ author, filterBlogPostId }) {
       </div>
     </section>
   );
-}
-
-export default Scrivito.connect(BlogPostMorePosts);
+});

--- a/src/Components/BlogPost/BlogPostNavigation.js
+++ b/src/Components/BlogPost/BlogPostNavigation.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import BlogPostDate from "./BlogPostDate";
+import { BlogPostDate } from "./BlogPostDate";
 
-const BlogPostNavigation = Scrivito.connect(({ currentPost }) => {
+export const BlogPostNavigation = Scrivito.connect(({ currentPost }) => {
   if (!currentPost || !currentPost.get("publishedAt")) return null;
 
   return (
@@ -83,5 +83,3 @@ const BlogPostPreviousLink = Scrivito.connect(({ currentBlogPost }) => {
     </Scrivito.LinkTag>
   );
 });
-
-export default BlogPostNavigation;

--- a/src/Components/BlogPost/BlogPostPreviewList.js
+++ b/src/Components/BlogPost/BlogPostPreviewList.js
@@ -1,12 +1,12 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 import { groupBy, truncate } from "lodash-es";
-import BlogPostDate from "./BlogPostDate";
-import formatDate from "../../utils/formatDate";
-import InPlaceEditingPlaceholder from "../InPlaceEditingPlaceholder";
-import isImage from "../../utils/isImage";
+import { BlogPostDate } from "./BlogPostDate";
+import { formatDate } from "../../utils/formatDate";
+import { InPlaceEditingPlaceholder } from "../InPlaceEditingPlaceholder";
+import { isImage } from "../../utils/isImage";
 
-const BlogPostPreviewList = Scrivito.connect(
+export const BlogPostPreviewList = Scrivito.connect(
   ({ maxItems, author, tag, filterBlogPostId }) => {
     let blogPosts = Scrivito.getClass("BlogPost")
       .all()
@@ -114,5 +114,3 @@ const BlogPostTitleImage = Scrivito.connect(({ post }) => {
     </Scrivito.LinkTag>
   );
 });
-
-export default BlogPostPreviewList;

--- a/src/Components/BlogPost/BlogPostTagList.js
+++ b/src/Components/BlogPost/BlogPostTagList.js
@@ -1,9 +1,11 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import navigateToBlogWithTag from "../../utils/navigateToBlogWithTag";
+import { navigateToBlogWithTag } from "../../utils/navigateToBlogWithTag";
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
-function BlogPostTagList({ tags }) {
+export const BlogPostTagList = Scrivito.connect(function BlogPostTagList({
+  tags,
+}) {
   return (
     <section>
       <div className="container">
@@ -29,7 +31,5 @@ function BlogPostTagList({ tags }) {
       </div>
     </section>
   );
-}
+});
 /* eslint-enable jsx-a11y/anchor-is-valid */
-
-export default Scrivito.connect(BlogPostTagList);

--- a/src/Components/CookieConsentBanner.js
+++ b/src/Components/CookieConsentBanner.js
@@ -3,27 +3,29 @@ import * as Scrivito from "scrivito";
 import { useCookieConsent } from "./CookieConsentContext";
 import cookieConsentIcon from "../assets/images/cookie_consent_icon.svg";
 
-function CookieConsentBanner() {
-  const consentUrl = cookieConsentUrl();
-  const [visible, setVisible] = React.useState(false);
-  const { cookieConsentChoice, acceptCookieConsent, declineCookieConsent } =
-    useCookieConsent();
+export const CookieConsentBanner = Scrivito.connect(
+  function CookieConsentBanner() {
+    const consentUrl = cookieConsentUrl();
+    const [visible, setVisible] = React.useState(false);
+    const { cookieConsentChoice, acceptCookieConsent, declineCookieConsent } =
+      useCookieConsent();
 
-  React.useEffect(() => {
-    setVisible(cookieConsentChoice === "undecided");
-  }, [cookieConsentChoice]);
+    React.useEffect(() => {
+      setVisible(cookieConsentChoice === "undecided");
+    }, [cookieConsentChoice]);
 
-  if (!visible || !consentUrl) return null;
+    if (!visible || !consentUrl) return null;
 
-  return (
-    <CookieBanner
-      url={consentUrl.url}
-      title={consentUrl.title}
-      onAccept={acceptCookieConsent}
-      onDecline={declineCookieConsent}
-    />
-  );
-}
+    return (
+      <CookieBanner
+        url={consentUrl.url}
+        title={consentUrl.title}
+        onAccept={acceptCookieConsent}
+        onDecline={declineCookieConsent}
+      />
+    );
+  }
+);
 
 function CookieBanner(props) {
   return (
@@ -84,5 +86,3 @@ function cookieConsentUrl() {
     title: cookieConsentLink.title() || "Learn more »",
   };
 }
-
-export default Scrivito.connect(CookieConsentBanner);

--- a/src/Components/CurrentPageMetadata.js
+++ b/src/Components/CurrentPageMetadata.js
@@ -1,10 +1,10 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 import { Helmet } from "react-helmet-async";
-import getMetadata from "../utils/getMetadata";
+import { getMetadata } from "../utils/getMetadata";
 import favicon from "../assets/images/favicon.png";
 
-const CurrentPageMetadata = Scrivito.connect(() => {
+export const CurrentPageMetadata = Scrivito.connect(() => {
   let lang = "en";
   let title = "";
   let meta = [];
@@ -35,5 +35,3 @@ const CurrentPageMetadata = Scrivito.connect(() => {
     />
   );
 });
-
-export default CurrentPageMetadata;

--- a/src/Components/ErrorBoundary.js
+++ b/src/Components/ErrorBoundary.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Helmet } from "react-helmet-async";
 
-class ErrorBoundary extends React.Component {
+export class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
 
@@ -50,5 +50,3 @@ const backgroundImage = [
   "linear-gradient(rgba(46, 53, 60, 0.7), rgba(46, 53, 60, 0.7))",
   "url(https://long-lasting-assets.scrivitojs.com/scrivito_example_app_js/500_error.jpeg)",
 ].join(", ");
-
-export default ErrorBoundary;

--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "./InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "./InPlaceEditingPlaceholder";
 
-function Footer() {
+export const Footer = Scrivito.connect(function Footer() {
   const root = Scrivito.Obj.root();
   if (!root) return null;
 
@@ -20,6 +20,4 @@ function Footer() {
       />
     </React.Fragment>
   );
-}
-
-export default Scrivito.connect(Footer);
+});

--- a/src/Components/Icon.js
+++ b/src/Components/Icon.js
@@ -12,7 +12,7 @@ function Icon({ icon, size, title }) {
   );
 }
 
-function IconComponent({ icon, size, link }) {
+export function IconComponent({ icon, size, link }) {
   if (!link) return <Icon icon={icon} size={size} />;
 
   const title = link.title() || "";
@@ -23,5 +23,3 @@ function IconComponent({ icon, size, link }) {
     </Scrivito.LinkTag>
   );
 }
-
-export default IconComponent;

--- a/src/Components/InPlaceEditingPlaceholder.js
+++ b/src/Components/InPlaceEditingPlaceholder.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import placeholderCss from "../utils/placeholderCss";
+import { placeholderCss } from "../utils/placeholderCss";
 
-const InPlaceEditingPlaceholder = ({ children, center, block }) => {
+export const InPlaceEditingPlaceholder = ({ children, center, block }) => {
   if (!Scrivito.isInPlaceEditingActive()) return null;
 
   const innerSpan = <span style={placeholderCss}>{children}</span>;
@@ -13,5 +13,3 @@ const InPlaceEditingPlaceholder = ({ children, center, block }) => {
 
   return innerSpan;
 };
-
-export default InPlaceEditingPlaceholder;

--- a/src/Components/Intercom.js
+++ b/src/Components/Intercom.js
@@ -2,41 +2,43 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 import { Helmet } from "react-helmet-async";
 
-class Intercom extends React.Component {
-  constructor(props) {
-    super(props);
+export const Intercom = Scrivito.connect(
+  class Intercom extends React.Component {
+    constructor(props) {
+      super(props);
 
-    this.state = { intercomAppId: "" };
+      this.state = { intercomAppId: "" };
+    }
+
+    componentDidMount() {
+      Scrivito.load(() => {
+        const rootPage = Scrivito.Obj.root();
+        if (!rootPage) return undefined;
+        return rootPage.get("intercomAppId");
+      }).then((intercomAppId) => {
+        if (intercomAppId) {
+          Scrivito.finishLoading().then(() => {
+            installIntercom(intercomAppId);
+            this.setState({ intercomAppId });
+          });
+        }
+      });
+    }
+
+    render() {
+      if (!this.state.intercomAppId) return null;
+
+      return (
+        <Helmet>
+          <script
+            async
+            src={`https://widget.intercom.io/widget/${this.state.intercomAppId}`}
+          />
+        </Helmet>
+      );
+    }
   }
-
-  componentDidMount() {
-    Scrivito.load(() => {
-      const rootPage = Scrivito.Obj.root();
-      if (!rootPage) return undefined;
-      return rootPage.get("intercomAppId");
-    }).then((intercomAppId) => {
-      if (intercomAppId) {
-        Scrivito.finishLoading().then(() => {
-          installIntercom(intercomAppId);
-          this.setState({ intercomAppId });
-        });
-      }
-    });
-  }
-
-  render() {
-    if (!this.state.intercomAppId) return null;
-
-    return (
-      <Helmet>
-        <script
-          async
-          src={`https://widget.intercom.io/widget/${this.state.intercomAppId}`}
-        />
-      </Helmet>
-    );
-  }
-}
+);
 
 function installIntercom(appId) {
   if (typeof window.Intercom === "function") {
@@ -52,5 +54,3 @@ function installIntercom(appId) {
     window.Intercom("boot", { app_id: appId });
   }
 }
-
-export default Scrivito.connect(Intercom);

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -108,8 +108,9 @@ export const Navigation = Scrivito.connect(
       }
 
       let videoUrl = "";
-      if (isVideoObj(backgroundImage))
+      if (isVideoObj(backgroundImage)) {
         videoUrl = urlFromBinary(backgroundImage);
+      }
 
       const topSectionStyle = {};
       if (navigationStyle === "transparentDark") {

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -1,13 +1,13 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 
-import currentPageNavigationOptions from "./Navigation/currentPageNavigationOptions";
-import FullNavigation from "./Navigation/FullNavigation";
-import LandingPageNavigation from "./Navigation/LandingPageNavigation";
-import NavigationSection from "./Navigation/NavigationSection";
-import ScrollToNextSectionLink from "./Navigation/ScrollToNextSectionLink";
-import isVideoObj from "../utils/isVideoObj";
-import urlFromBinary from "../utils/urlFromBinary";
+import { currentPageNavigationOptions } from "./Navigation/currentPageNavigationOptions";
+import { FullNavigation } from "./Navigation/FullNavigation";
+import { LandingPageNavigation } from "./Navigation/LandingPageNavigation";
+import { NavigationSection } from "./Navigation/NavigationSection";
+import { ScrollToNextSectionLink } from "./Navigation/ScrollToNextSectionLink";
+import { isVideoObj } from "../utils/isVideoObj";
+import { urlFromBinary } from "../utils/urlFromBinary";
 
 function ActualNavigation({
   showAsLandingPage,
@@ -47,128 +47,129 @@ function BackgroundVideo({ videoUrl }) {
   );
 }
 
-class Navigation extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      scrolled: false,
-      showSearch: false,
-    };
+export const Navigation = Scrivito.connect(
+  class Navigation extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        scrolled: false,
+        showSearch: false,
+      };
 
-    this.handleScroll = this.handleScroll.bind(this);
-    this.toggleSearch = this.toggleSearch.bind(this);
-  }
-
-  componentDidMount() {
-    window.addEventListener("scroll", this.handleScroll);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("scroll", this.handleScroll);
-  }
-
-  handleScroll(event) {
-    // see https://stackoverflow.com/q/28633221/881759 for discussion about pageYOffset
-    const scrollTop = event.currentTarget.pageYOffset;
-    const scrolledToBe = scrollTop !== 0;
-
-    if (this.state.scrolled !== scrolledToBe) {
-      // only set state, if needed. Otherwise a render will be triggered on _every_ scroll.
-      this.setState({ scrolled: scrolledToBe });
-    }
-  }
-
-  toggleSearch() {
-    this.setState({ showSearch: !this.state.showSearch });
-  }
-
-  render() {
-    const {
-      navigationStyle,
-      backgroundImage,
-      heightClassName,
-      useGradient,
-      showAsLandingPage,
-    } = currentPageNavigationOptions();
-
-    const topSectionClassNames = ["navbar-fixed"];
-    if (this.state.scrolled) topSectionClassNames.push("scrolled");
-
-    if (navigationStyle === "transparentDark") {
-      topSectionClassNames.push("bg-dark-image");
-    } else {
-      topSectionClassNames.push("bg-white", "nav-only");
+      this.handleScroll = this.handleScroll.bind(this);
+      this.toggleSearch = this.toggleSearch.bind(this);
     }
 
-    const bootstrapNavbarClassNames = [];
-    if (this.state.showSearch) bootstrapNavbarClassNames.push("show-search");
-    if (navigationStyle === "transparentDark") {
-      bootstrapNavbarClassNames.push("navbar-transparent");
+    componentDidMount() {
+      window.addEventListener("scroll", this.handleScroll);
     }
 
-    let videoUrl = "";
-    if (isVideoObj(backgroundImage)) videoUrl = urlFromBinary(backgroundImage);
+    componentWillUnmount() {
+      window.removeEventListener("scroll", this.handleScroll);
+    }
 
-    const topSectionStyle = {};
-    if (navigationStyle === "transparentDark") {
-      if (backgroundImage) {
-        if (useGradient) {
-          topSectionStyle.background = [
-            {
-              image:
-                "radial-gradient(ellipse at center, rgba(58, 65, 81,.5) 0%," +
-                " rgba(58, 65, 81,1) 90%)",
-            },
-            {
-              image:
-                "linear-gradient(to bottom, rgba(58, 65, 81,0) 0%, rgba(58, 65, 81,1) 90%)",
-            },
-          ];
-          if (!isVideoObj(backgroundImage)) {
-            topSectionStyle.background.push({
-              image: backgroundImage,
-              position: "bottom",
-            });
-          }
-        } else {
-          topSectionStyle.background = [
-            {
-              image:
-                "linear-gradient(rgba(58, 65, 81, 0.7), rgba(58, 65, 81, 0.7))",
-            },
-          ];
-          if (!isVideoObj(backgroundImage)) {
-            topSectionStyle.background.push({ image: backgroundImage });
-          }
-        }
+    handleScroll(event) {
+      // see https://stackoverflow.com/q/28633221/881759 for discussion about pageYOffset
+      const scrollTop = event.currentTarget.pageYOffset;
+      const scrolledToBe = scrollTop !== 0;
+
+      if (this.state.scrolled !== scrolledToBe) {
+        // only set state, if needed. Otherwise a render will be triggered on _every_ scroll.
+        this.setState({ scrolled: scrolledToBe });
       }
     }
 
-    if (heightClassName) topSectionClassNames.push(heightClassName);
+    toggleSearch() {
+      this.setState({ showSearch: !this.state.showSearch });
+    }
 
-    return (
-      <React.Fragment>
-        <Scrivito.BackgroundImageTag
-          tag="section"
-          className={topSectionClassNames.join(" ")}
-          style={topSectionStyle}
-        >
-          <BackgroundVideo videoUrl={videoUrl} />
-          <ActualNavigation
-            showAsLandingPage={showAsLandingPage}
-            bootstrapNavbarClassNames={bootstrapNavbarClassNames}
-            toggleSearch={this.toggleSearch}
-            showSearch={this.state.showSearch}
-            scrolled={this.state.scrolled}
-            navigationStyle={navigationStyle}
-          />
-          <NavigationSection heightClassName={heightClassName} />
-          <ScrollToNextSectionLink heightClassName={heightClassName} />
-        </Scrivito.BackgroundImageTag>
-        <div id="mainContent" />
-      </React.Fragment>
-    );
+    render() {
+      const {
+        navigationStyle,
+        backgroundImage,
+        heightClassName,
+        useGradient,
+        showAsLandingPage,
+      } = currentPageNavigationOptions();
+
+      const topSectionClassNames = ["navbar-fixed"];
+      if (this.state.scrolled) topSectionClassNames.push("scrolled");
+
+      if (navigationStyle === "transparentDark") {
+        topSectionClassNames.push("bg-dark-image");
+      } else {
+        topSectionClassNames.push("bg-white", "nav-only");
+      }
+
+      const bootstrapNavbarClassNames = [];
+      if (this.state.showSearch) bootstrapNavbarClassNames.push("show-search");
+      if (navigationStyle === "transparentDark") {
+        bootstrapNavbarClassNames.push("navbar-transparent");
+      }
+
+      let videoUrl = "";
+      if (isVideoObj(backgroundImage))
+        videoUrl = urlFromBinary(backgroundImage);
+
+      const topSectionStyle = {};
+      if (navigationStyle === "transparentDark") {
+        if (backgroundImage) {
+          if (useGradient) {
+            topSectionStyle.background = [
+              {
+                image:
+                  "radial-gradient(ellipse at center, rgba(58, 65, 81,.5) 0%," +
+                  " rgba(58, 65, 81,1) 90%)",
+              },
+              {
+                image:
+                  "linear-gradient(to bottom, rgba(58, 65, 81,0) 0%, rgba(58, 65, 81,1) 90%)",
+              },
+            ];
+            if (!isVideoObj(backgroundImage)) {
+              topSectionStyle.background.push({
+                image: backgroundImage,
+                position: "bottom",
+              });
+            }
+          } else {
+            topSectionStyle.background = [
+              {
+                image:
+                  "linear-gradient(rgba(58, 65, 81, 0.7), rgba(58, 65, 81, 0.7))",
+              },
+            ];
+            if (!isVideoObj(backgroundImage)) {
+              topSectionStyle.background.push({ image: backgroundImage });
+            }
+          }
+        }
+      }
+
+      if (heightClassName) topSectionClassNames.push(heightClassName);
+
+      return (
+        <React.Fragment>
+          <Scrivito.BackgroundImageTag
+            tag="section"
+            className={topSectionClassNames.join(" ")}
+            style={topSectionStyle}
+          >
+            <BackgroundVideo videoUrl={videoUrl} />
+            <ActualNavigation
+              showAsLandingPage={showAsLandingPage}
+              bootstrapNavbarClassNames={bootstrapNavbarClassNames}
+              toggleSearch={this.toggleSearch}
+              showSearch={this.state.showSearch}
+              scrolled={this.state.scrolled}
+              navigationStyle={navigationStyle}
+            />
+            <NavigationSection heightClassName={heightClassName} />
+            <ScrollToNextSectionLink heightClassName={heightClassName} />
+          </Scrivito.BackgroundImageTag>
+          <div id="mainContent" />
+        </React.Fragment>
+      );
+    }
   }
-}
-
-export default Scrivito.connect(Navigation);
+);

--- a/src/Components/Navigation/CollapseToggle.js
+++ b/src/Components/Navigation/CollapseToggle.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-function CollapseToggle({ expanded, toggleExpanded }) {
+export function CollapseToggle({ expanded, toggleExpanded }) {
   const classNames = ["navbar-toggler"];
   if (!expanded) classNames.push("collapsed");
 
@@ -19,5 +19,3 @@ function CollapseToggle({ expanded, toggleExpanded }) {
     </button>
   );
 }
-
-export default CollapseToggle;

--- a/src/Components/Navigation/FullNavigation.js
+++ b/src/Components/Navigation/FullNavigation.js
@@ -1,11 +1,11 @@
 import * as React from "react";
 import Collapse from "react-bootstrap/Collapse";
-import CollapseToggle from "./CollapseToggle";
-import Logo from "./Logo";
-import Nav from "./Nav";
+import { CollapseToggle } from "./CollapseToggle";
+import { Logo } from "./Logo";
+import { Nav } from "./Nav";
 import { SearchBox, SearchIcon } from "./Search";
 
-class FullNavigation extends React.Component {
+export class FullNavigation extends React.Component {
   constructor(props) {
     super(props);
 
@@ -69,5 +69,3 @@ class FullNavigation extends React.Component {
     );
   }
 }
-
-export default FullNavigation;

--- a/src/Components/Navigation/LandingPageNavigation.js
+++ b/src/Components/Navigation/LandingPageNavigation.js
@@ -1,12 +1,10 @@
 import * as React from "react";
-import Logo from "./Logo";
+import { Logo } from "./Logo";
 
-function LandingPageNavigation({ navigationStyle }) {
+export function LandingPageNavigation({ navigationStyle }) {
   return (
     <div className="nav-landing-page">
       <Logo scrolled={false} navigationStyle={navigationStyle} />
     </div>
   );
 }
-
-export default LandingPageNavigation;

--- a/src/Components/Navigation/Logo.js
+++ b/src/Components/Navigation/Logo.js
@@ -17,7 +17,10 @@ function logoObj({ scrolled, navigationStyle }) {
   return undefined;
 }
 
-function Logo({ scrolled, navigationStyle }) {
+export const Logo = Scrivito.connect(function Logo({
+  scrolled,
+  navigationStyle,
+}) {
   if (!Scrivito.Obj.root()) return null;
 
   const logo = logoObj({ scrolled, navigationStyle });
@@ -27,6 +30,4 @@ function Logo({ scrolled, navigationStyle }) {
       <Scrivito.ImageTag content={logo} alt="Logo" />
     </Scrivito.LinkTag>
   );
-}
-
-export default Scrivito.connect(Logo);
+});

--- a/src/Components/Navigation/Nav.js
+++ b/src/Components/Navigation/Nav.js
@@ -1,56 +1,56 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import NavChild from "./NavChild";
+import { NavChild } from "./NavChild";
 
-class Nav extends React.Component {
-  constructor(props) {
-    super(props);
+export const Nav = Scrivito.connect(
+  class Nav extends React.Component {
+    constructor(props) {
+      super(props);
 
-    this.registeredDropdowns = [];
+      this.registeredDropdowns = [];
 
-    this.closeAll = this.closeAll.bind(this);
-    this.closeDropdowns = this.closeDropdowns.bind(this);
-    this.registerDropdown = this.registerDropdown.bind(this);
-    this.unregisterDropdown = this.unregisterDropdown.bind(this);
+      this.closeAll = this.closeAll.bind(this);
+      this.closeDropdowns = this.closeDropdowns.bind(this);
+      this.registerDropdown = this.registerDropdown.bind(this);
+      this.unregisterDropdown = this.unregisterDropdown.bind(this);
+    }
+
+    closeAll() {
+      this.props.closeExpanded();
+      this.closeDropdowns();
+    }
+
+    closeDropdowns() {
+      this.registeredDropdowns.forEach((dropdown) => dropdown.closeDropdown());
+    }
+
+    registerDropdown(dropdownComponent) {
+      this.registeredDropdowns.push(dropdownComponent);
+    }
+
+    unregisterDropdown(dropdownComponent) {
+      this.registeredDropdowns = this.registeredDropdowns.filter(
+        (i) => i !== dropdownComponent
+      );
+    }
+
+    render() {
+      return (
+        <Scrivito.ChildListTag
+          className="nav navbar-nav navbar-right"
+          parent={Scrivito.Obj.root()}
+          renderChild={(child) => (
+            <NavChild
+              child={child}
+              registerDropdown={this.registerDropdown}
+              unregisterDropdown={this.unregisterDropdown}
+              closeAll={this.closeAll}
+              closeDropdowns={this.closeDropdowns}
+              expanded={this.props.expanded}
+            />
+          )}
+        />
+      );
+    }
   }
-
-  closeAll() {
-    this.props.closeExpanded();
-    this.closeDropdowns();
-  }
-
-  closeDropdowns() {
-    this.registeredDropdowns.forEach((dropdown) => dropdown.closeDropdown());
-  }
-
-  registerDropdown(dropdownComponent) {
-    this.registeredDropdowns.push(dropdownComponent);
-  }
-
-  unregisterDropdown(dropdownComponent) {
-    this.registeredDropdowns = this.registeredDropdowns.filter(
-      (i) => i !== dropdownComponent
-    );
-  }
-
-  render() {
-    return (
-      <Scrivito.ChildListTag
-        className="nav navbar-nav navbar-right"
-        parent={Scrivito.Obj.root()}
-        renderChild={(child) => (
-          <NavChild
-            child={child}
-            registerDropdown={this.registerDropdown}
-            unregisterDropdown={this.unregisterDropdown}
-            closeAll={this.closeAll}
-            closeDropdowns={this.closeDropdowns}
-            expanded={this.props.expanded}
-          />
-        )}
-      />
-    );
-  }
-}
-
-export default Scrivito.connect(Nav);
+);

--- a/src/Components/Navigation/NavChild.js
+++ b/src/Components/Navigation/NavChild.js
@@ -51,7 +51,7 @@ class BaseNavChild extends React.Component {
   }
 }
 
-const NavChild = Scrivito.connect(BaseNavChild);
+export const NavChild = Scrivito.connect(BaseNavChild);
 
 const NavSingleChild = Scrivito.connect(({ child, open, ...otherProps }) => {
   const classNames = ["nav-item"];
@@ -115,5 +115,3 @@ function isActive(page) {
 
   return false;
 }
-
-export default NavChild;

--- a/src/Components/Navigation/NavigationSection.js
+++ b/src/Components/Navigation/NavigationSection.js
@@ -1,7 +1,9 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 
-function NavigationSection({ heightClassName }) {
+export const NavigationSection = Scrivito.connect(function NavigationSection({
+  heightClassName,
+}) {
   if (!["full-height", "medium-height"].includes(heightClassName)) return null;
 
   if (!Scrivito.currentPage()) return null;
@@ -16,6 +18,4 @@ function NavigationSection({ heightClassName }) {
       attribute="navigationSection"
     />
   );
-}
-
-export default Scrivito.connect(NavigationSection);
+});

--- a/src/Components/Navigation/ScrollToNextSectionLink.js
+++ b/src/Components/Navigation/ScrollToNextSectionLink.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-function ScrollToNextSectionLink({ heightClassName }) {
+export function ScrollToNextSectionLink({ heightClassName }) {
   if (heightClassName !== "full-height") return null;
 
   return (
@@ -13,5 +13,3 @@ function ScrollToNextSectionLink({ heightClassName }) {
     </a>
   );
 }
-
-export default ScrollToNextSectionLink;

--- a/src/Components/Navigation/currentPageNavigationOptions.js
+++ b/src/Components/Navigation/currentPageNavigationOptions.js
@@ -1,7 +1,7 @@
 import * as Scrivito from "scrivito";
-import isVideoObj from "../../utils/isVideoObj";
+import { isVideoObj } from "../../utils/isVideoObj";
 
-function currentPageNavigationOptions() {
+export function currentPageNavigationOptions() {
   if (Scrivito.currentPage()) {
     switch (Scrivito.currentPage().objClass()) {
       case "Blog":
@@ -131,5 +131,3 @@ function imageWithMediumHeightOrMinHeight(image) {
     heightClassName: "min-height",
   };
 }
-
-export default currentPageNavigationOptions;

--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -50,12 +50,4 @@ class NotFoundErrorPage extends React.Component {
   }
 }
 
-const ConnectedNotFoundErrorPage = Scrivito.connect(NotFoundErrorPage);
-
-export default function WrappedNotFoundErrorPage() {
-  return (
-    <Scrivito.NotFoundErrorPage>
-      <ConnectedNotFoundErrorPage />
-    </Scrivito.NotFoundErrorPage>
-  );
-}
+export default Scrivito.connect(NotFoundErrorPage);

--- a/src/Components/NotFoundErrorPage.js
+++ b/src/Components/NotFoundErrorPage.js
@@ -2,52 +2,54 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 import { Helmet } from "react-helmet-async";
 
-class NotFoundErrorPage extends React.Component {
-  componentDidMount() {
-    const statusCode = "status-code=404-not-found";
-    const { search } = window.location;
+export const NotFoundErrorPage = Scrivito.connect(
+  class NotFoundErrorPage extends React.Component {
+    componentDidMount() {
+      const statusCode = "status-code=404-not-found";
+      const { search } = window.location;
 
-    if (!Scrivito.isEditorLoggedIn() && !search.includes(statusCode)) {
-      window.location.search = search ? `${search}&${statusCode}` : statusCode;
+      if (!Scrivito.isEditorLoggedIn() && !search.includes(statusCode)) {
+        window.location.search = search
+          ? `${search}&${statusCode}`
+          : statusCode;
+      }
+    }
+
+    render() {
+      const backgroundImage = [
+        "linear-gradient(rgba(46, 53, 60, 0.7), rgba(46, 53, 60, 0.7))",
+        "url(https://long-lasting-assets.scrivitojs.com/scrivito_example_app_js/404_not_found.jpeg)",
+      ].join(", ");
+
+      return (
+        <React.Fragment>
+          <section
+            className="bg-dark-image full-height"
+            style={{ background: "no-repeat center / cover", backgroundImage }}
+          >
+            <div className="container">
+              <div className="text-center">
+                <h1 className="hero-bold">Ooops</h1>
+              </div>
+              <div className="text-center">
+                <h2 className="hero-small">
+                  The page you are looking for does not exist.
+                </h2>
+              </div>
+              <div className="text-center">
+                <Scrivito.LinkTag
+                  to={Scrivito.Obj.root()}
+                  className="btn btn-primary"
+                >
+                  Go to mainpage{" "}
+                  <i className="fa fa-angle-right fa-4" aria-hidden="true" />
+                </Scrivito.LinkTag>
+              </div>
+            </div>
+          </section>
+          <Helmet meta={[{ name: "prerender-status-code", content: "404" }]} />
+        </React.Fragment>
+      );
     }
   }
-
-  render() {
-    const backgroundImage = [
-      "linear-gradient(rgba(46, 53, 60, 0.7), rgba(46, 53, 60, 0.7))",
-      "url(https://long-lasting-assets.scrivitojs.com/scrivito_example_app_js/404_not_found.jpeg)",
-    ].join(", ");
-
-    return (
-      <React.Fragment>
-        <section
-          className="bg-dark-image full-height"
-          style={{ background: "no-repeat center / cover", backgroundImage }}
-        >
-          <div className="container">
-            <div className="text-center">
-              <h1 className="hero-bold">Ooops</h1>
-            </div>
-            <div className="text-center">
-              <h2 className="hero-small">
-                The page you are looking for does not exist.
-              </h2>
-            </div>
-            <div className="text-center">
-              <Scrivito.LinkTag
-                to={Scrivito.Obj.root()}
-                className="btn btn-primary"
-              >
-                Go to mainpage{" "}
-                <i className="fa fa-angle-right fa-4" aria-hidden="true" />
-              </Scrivito.LinkTag>
-            </div>
-          </div>
-        </section>
-        <Helmet meta={[{ name: "prerender-status-code", content: "404" }]} />
-      </React.Fragment>
-    );
-  }
-}
-
-export default Scrivito.connect(NotFoundErrorPage);
+);

--- a/src/Components/SchemaDotOrg.js
+++ b/src/Components/SchemaDotOrg.js
@@ -3,14 +3,14 @@ import * as Scrivito from "scrivito";
 import isEmpty from "is-empty";
 import escapeHtml from "escape-html";
 import { isPlainObject } from "lodash-es";
-import dataFromAuthor from "./SchemaDotOrg/dataFromAuthor";
-import dataFromEvent from "./SchemaDotOrg/dataFromEvent";
-import dataFromJob from "./SchemaDotOrg/dataFromJob";
-import dataFromBlog from "./SchemaDotOrg/dataFromBlog";
-import dataFromBlogPost from "./SchemaDotOrg/dataFromBlogPost";
-import dataFromAddressWidget from "./SchemaDotOrg/dataFromAddressWidget";
+import { dataFromAuthor } from "./SchemaDotOrg/dataFromAuthor";
+import { dataFromEvent } from "./SchemaDotOrg/dataFromEvent";
+import { dataFromJob } from "./SchemaDotOrg/dataFromJob";
+import { dataFromBlog } from "./SchemaDotOrg/dataFromBlog";
+import { dataFromBlogPost } from "./SchemaDotOrg/dataFromBlogPost";
+import { dataFromAddressWidget } from "./SchemaDotOrg/dataFromAddressWidget";
 
-const SchemaDotOrg = Scrivito.connect(({ content }) => {
+export const SchemaDotOrg = Scrivito.connect(({ content }) => {
   const data = pruneEmptyValues(dataFromItem(content));
 
   return (
@@ -78,5 +78,3 @@ function pickBy(data, fn) {
     Object.entries(data).filter(([_key, value]) => fn(value))
   );
 }
-
-export default SchemaDotOrg;

--- a/src/Components/SchemaDotOrg/dataFromAddressWidget.js
+++ b/src/Components/SchemaDotOrg/dataFromAddressWidget.js
@@ -1,4 +1,4 @@
-function dataFromAddressWidget(addressWidget) {
+export function dataFromAddressWidget(addressWidget) {
   return {
     "@type": "Place",
     name: addressWidget.get("locationName"),
@@ -18,5 +18,3 @@ function addressFromAddressWidget(addressWidget) {
     addressCountry: addressWidget.get("locationCountry"),
   };
 }
-
-export default dataFromAddressWidget;

--- a/src/Components/SchemaDotOrg/dataFromAuthor.js
+++ b/src/Components/SchemaDotOrg/dataFromAuthor.js
@@ -1,6 +1,6 @@
-import urlFromBinary from "../../utils/urlFromBinary";
+import { urlFromBinary } from "../../utils/urlFromBinary";
 
-function dataFromAuthor(author) {
+export function dataFromAuthor(author) {
   return {
     "@context": "http://schema.org",
     "@type": "Person",
@@ -9,5 +9,3 @@ function dataFromAuthor(author) {
     image: urlFromBinary(author.get("image")),
   };
 }
-
-export default dataFromAuthor;

--- a/src/Components/SchemaDotOrg/dataFromBlog.js
+++ b/src/Components/SchemaDotOrg/dataFromBlog.js
@@ -1,7 +1,7 @@
-import urlFromBinary from "../../utils/urlFromBinary";
-import isVideoObj from "../../utils/isVideoObj";
+import { urlFromBinary } from "../../utils/urlFromBinary";
+import { isVideoObj } from "../../utils/isVideoObj";
 
-function dataFromBlog(blog) {
+export function dataFromBlog(blog) {
   const schema = {
     "@context": "http://schema.org",
     "@type": "Blog",
@@ -15,5 +15,3 @@ function dataFromBlog(blog) {
 
   return schema;
 }
-
-export default dataFromBlog;

--- a/src/Components/SchemaDotOrg/dataFromBlogPost.js
+++ b/src/Components/SchemaDotOrg/dataFromBlogPost.js
@@ -1,10 +1,10 @@
 import * as Scrivito from "scrivito";
 import { truncate } from "lodash-es";
-import dataFromAuthor from "./dataFromAuthor";
-import formatDate from "../../utils/formatDate";
-import urlFromBinary from "../../utils/urlFromBinary";
+import { dataFromAuthor } from "./dataFromAuthor";
+import { formatDate } from "../../utils/formatDate";
+import { urlFromBinary } from "../../utils/urlFromBinary";
 
-function dataFromBlogPost(blogPost) {
+export function dataFromBlogPost(blogPost) {
   const description = Scrivito.extractText(blogPost, { length: 330 });
   return {
     "@context": "http://schema.org",
@@ -19,5 +19,3 @@ function dataFromBlogPost(blogPost) {
     keywords: blogPost.get("tags").join(", "),
   };
 }
-
-export default dataFromBlogPost;

--- a/src/Components/SchemaDotOrg/dataFromEvent.js
+++ b/src/Components/SchemaDotOrg/dataFromEvent.js
@@ -1,8 +1,8 @@
 import * as Scrivito from "scrivito";
-import formatDate from "../../utils/formatDate";
-import urlFromBinary from "../../utils/urlFromBinary";
+import { formatDate } from "../../utils/formatDate";
+import { urlFromBinary } from "../../utils/urlFromBinary";
 
-function dataFromEvent(event) {
+export function dataFromEvent(event) {
   return {
     "@context": "http://schema.org",
     "@type": "Event",
@@ -33,5 +33,3 @@ function addressFromEvent(event) {
     addressCountry: event.get("locationCountry"),
   };
 }
-
-export default dataFromEvent;

--- a/src/Components/SchemaDotOrg/dataFromJob.js
+++ b/src/Components/SchemaDotOrg/dataFromJob.js
@@ -1,7 +1,7 @@
 import * as Scrivito from "scrivito";
-import formatDate from "../../utils/formatDate";
+import { formatDate } from "../../utils/formatDate";
 
-function dataFromJob(job) {
+export function dataFromJob(job) {
   return {
     "@context": "http://schema.org",
     "@type": "JobPosting",
@@ -37,5 +37,3 @@ function addressFromJob(job) {
     addressCountry: job.get("locationCountry"),
   };
 }
-
-export default dataFromJob;

--- a/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
+++ b/src/Components/ScrivitoExtensions/ColumnsEditorTab.js
@@ -2,9 +2,9 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 import Draggable from "react-draggable";
 import { flatten, isEqual, last, take, takeRight, times } from "lodash-es";
-import ColumnWidget from "../../Widgets/ColumnWidget/ColumnWidgetClass";
+import { ColumnWidget } from "../../Widgets/ColumnWidget/ColumnWidgetClass";
 
-function ColumnsEditorTab({ widget }) {
+export function ColumnsEditorTab({ widget }) {
   const includedWidgetIds = calculateContentIds(calculateContents(widget));
 
   return (
@@ -17,8 +17,6 @@ function ColumnsEditorTab({ widget }) {
     />
   );
 }
-
-export default ColumnsEditorTab;
 
 const ColumnsEditor = Scrivito.connect(({ widget, readOnly, currentGrid }) => {
   const originalContents = React.useMemo(

--- a/src/Components/ScrivitoExtensions/ContentProperty.js
+++ b/src/Components/ScrivitoExtensions/ContentProperty.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 
-const ContentProperty = Scrivito.connect(
+export const ContentProperty = Scrivito.connect(
   ({ content, attribute, title, description }) => {
     const validationResults = Scrivito.validationResultsFor(content, attribute);
     const highestSeverity = findHighestSeverity(validationResults);
@@ -35,8 +35,6 @@ const ContentProperty = Scrivito.connect(
     );
   }
 );
-
-export default ContentProperty;
 
 function findHighestSeverity(validationResults) {
   const highestSeverityValidation =

--- a/src/Components/ScrivitoExtensions/IconEditorTab.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab.js
@@ -1,11 +1,11 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import AllIcons from "./IconEditorTab/AllIcons";
-import IconComponent from "../Icon";
-import IconSearch from "./IconEditorTab/IconSearch";
-import IconSearchResults from "./IconEditorTab/IconSearchResults";
+import { AllIcons } from "./IconEditorTab/AllIcons";
+import { IconComponent } from "../Icon";
+import { IconSearch } from "./IconEditorTab/IconSearch";
+import { IconSearchResults } from "./IconEditorTab/IconSearchResults";
 
-function IconEditorTab({ widget }) {
+export function IconEditorTab({ widget }) {
   const [searchValue, setSearchValue] = React.useState("");
   const currentIcon = widget.get("icon");
 
@@ -52,5 +52,3 @@ function IconEditorTab({ widget }) {
     widget.update({ icon });
   }
 }
-
-export default IconEditorTab;

--- a/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/AllIcons.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { take } from "lodash-es";
-import fontAwesomeIcons from "./fontAwesomeIcons";
+import { fontAwesomeIcons } from "./fontAwesomeIcons";
 
-function AllIcons({ setWidgetIcon, currentIcon, hide }) {
+export function AllIcons({ setWidgetIcon, currentIcon, hide }) {
   const [initialRender, setInitialRender] = React.useState(true);
 
   const categoryMap = React.useMemo(() => {
@@ -110,5 +110,3 @@ function Category({ category, icons, currentIcon, setWidgetIcon }) {
   );
 }
 /* eslint-enable jsx-a11y/anchor-is-valid */
-
-export default AllIcons;

--- a/src/Components/ScrivitoExtensions/IconEditorTab/IconSearch.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/IconSearch.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-function IconSearch({ setSearchValue, searchValue }) {
+export function IconSearch({ setSearchValue, searchValue }) {
   return (
     <div id="search">
       <label htmlFor="search-input">
@@ -48,5 +48,3 @@ function ClearSearchButton({ setSearchValue, searchValue }) {
   );
 }
 /* eslint-enable jsx-a11y/anchor-is-valid */
-
-export default IconSearch;

--- a/src/Components/ScrivitoExtensions/IconEditorTab/IconSearchResults.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/IconSearchResults.js
@@ -1,9 +1,9 @@
 import * as React from "react";
 import Fuse from "fuse.js";
-import fontAwesomeIcons from "./fontAwesomeIcons";
-import SingleIcon from "./SingleIcon";
+import { fontAwesomeIcons } from "./fontAwesomeIcons";
+import { SingleIcon } from "./SingleIcon";
 
-function IconSearchResults({ searchValue, setWidgetIcon, currentIcon }) {
+export function IconSearchResults({ searchValue, setWidgetIcon, currentIcon }) {
   const fuse = React.useMemo(() => {
     const fuseOptions = {
       threshold: 0.2,
@@ -39,5 +39,3 @@ function IconSearchResults({ searchValue, setWidgetIcon, currentIcon }) {
     </div>
   );
 }
-
-export default IconSearchResults;

--- a/src/Components/ScrivitoExtensions/IconEditorTab/SingleIcon.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/SingleIcon.js
@@ -1,8 +1,8 @@
 import * as React from "react";
-import IconComponent from "../../Icon";
+import { IconComponent } from "../../Icon";
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
-function SingleIcon({ icon, setWidgetIcon, currentIcon }) {
+export function SingleIcon({ icon, setWidgetIcon, currentIcon }) {
   const cssIcon = `fa-${icon.id}`;
 
   const aClassNames = [];
@@ -23,5 +23,3 @@ function SingleIcon({ icon, setWidgetIcon, currentIcon }) {
   );
 }
 /* eslint-enable jsx-a11y/anchor-is-valid */
-
-export default SingleIcon;

--- a/src/Components/ScrivitoExtensions/IconEditorTab/fontAwesomeIcons.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/fontAwesomeIcons.js
@@ -1,4 +1,4 @@
-const fontAwesomeIcons = [
+export const fontAwesomeIcons = [
   {
     name: "Glass",
     id: "glass",
@@ -4042,5 +4042,3 @@ const fontAwesomeIcons = [
     categories: ["Brand icons"],
   },
 ];
-
-export default fontAwesomeIcons;

--- a/src/Components/ScrivitoExtensions/SocialCardsTab.js
+++ b/src/Components/ScrivitoExtensions/SocialCardsTab.js
@@ -1,9 +1,9 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import ContentProperty from "./ContentProperty";
-import getMetadata from "../../utils/getMetadata";
+import { ContentProperty } from "./ContentProperty";
+import { getMetadata } from "../../utils/getMetadata";
 
-function SocialCardsTab({ obj }) {
+export function SocialCardsTab({ obj }) {
   const uiContext = Scrivito.uiContext();
   if (uiContext === undefined) return null;
 
@@ -33,8 +33,6 @@ function SocialCardsTab({ obj }) {
     </div>
   );
 }
-
-export default SocialCardsTab;
 
 const TwitterInput = Scrivito.connect(({ obj }) => (
   <div>

--- a/src/Components/TagList.js
+++ b/src/Components/TagList.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
-function TagList({ showTags, tags, currentTag, setTag }) {
+export function TagList({ showTags, tags, currentTag, setTag }) {
   if (!showTags) return null;
 
   const onClick = (e, tag) => {
@@ -51,5 +51,3 @@ function TagList({ showTags, tags, currentTag, setTag }) {
   );
 }
 /* eslint-enable jsx-a11y/anchor-is-valid */
-
-export default TagList;

--- a/src/Components/Tracking.js
+++ b/src/Components/Tracking.js
@@ -3,7 +3,7 @@ import * as Scrivito from "scrivito";
 import { Helmet } from "react-helmet-async";
 import { useCookieConsent } from "./CookieConsentContext";
 
-export default function Tracking() {
+export function Tracking() {
   const [trackingEnabled, setTrackingEnabled] = React.useState(false);
   const { cookieConsentChoice } = useCookieConsent();
 

--- a/src/Objs/Author/AuthorComponent.js
+++ b/src/Objs/Author/AuthorComponent.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import AuthorImage from "../../Components/AuthorImage";
-import BlogPostMorePosts from "../../Components/BlogPost/BlogPostMorePosts";
-import SchemaDotOrg from "../../Components/SchemaDotOrg";
+import { AuthorImage } from "../../Components/AuthorImage";
+import { BlogPostMorePosts } from "../../Components/BlogPost/BlogPostMorePosts";
+import { SchemaDotOrg } from "../../Components/SchemaDotOrg";
 
 Scrivito.provideComponent("Author", ({ page }) => (
   <React.Fragment>

--- a/src/Objs/Author/AuthorObjClass.js
+++ b/src/Objs/Author/AuthorObjClass.js
@@ -1,7 +1,7 @@
 import * as Scrivito from "scrivito";
-import metadataAttributes from "../_metadataAttributes";
+import { metadataAttributes } from "../_metadataAttributes";
 
-const Author = Scrivito.provideObjClass("Author", {
+export const Author = Scrivito.provideObjClass("Author", {
   attributes: {
     title: "string",
     description: "string",
@@ -10,5 +10,3 @@ const Author = Scrivito.provideObjClass("Author", {
   },
   extractTextAttributes: ["description"],
 });
-
-export default Author;

--- a/src/Objs/Blog/BlogComponent.js
+++ b/src/Objs/Blog/BlogComponent.js
@@ -1,9 +1,9 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import BlogPost from "../BlogPost/BlogPostObjClass";
-import navigateToBlogWithTag from "../../utils/navigateToBlogWithTag";
-import SchemaDotOrg from "../../Components/SchemaDotOrg";
-import TagList from "../../Components/TagList";
+import { BlogPost } from "../BlogPost/BlogPostObjClass";
+import { navigateToBlogWithTag } from "../../utils/navigateToBlogWithTag";
+import { SchemaDotOrg } from "../../Components/SchemaDotOrg";
+import { TagList } from "../../Components/TagList";
 
 Scrivito.provideComponent("Blog", ({ page, params }) => {
   const tags = [...BlogPost.all().facet("tags")].map((facet) => facet.name());

--- a/src/Objs/Blog/BlogEditingConfig.js
+++ b/src/Objs/Blog/BlogEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import blogObjIcon from "../../assets/images/blog_obj.svg";
-import SectionWidget from "../../Widgets/SectionWidget/SectionWidgetClass";
+import { SectionWidget } from "../../Widgets/SectionWidget/SectionWidgetClass";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,

--- a/src/Objs/Blog/BlogObjClass.js
+++ b/src/Objs/Blog/BlogObjClass.js
@@ -1,7 +1,7 @@
 import * as Scrivito from "scrivito";
-import metadataAttributes from "../_metadataAttributes";
+import { metadataAttributes } from "../_metadataAttributes";
 
-const Blog = Scrivito.provideObjClass("Blog", {
+export const Blog = Scrivito.provideObjClass("Blog", {
   attributes: {
     title: "string",
     navigationBackgroundImage: ["reference", { only: ["Image"] }],
@@ -10,5 +10,3 @@ const Blog = Scrivito.provideObjClass("Blog", {
   },
   extractTextAttributes: ["body"],
 });
-
-export default Blog;

--- a/src/Objs/BlogPost/BlogPostComponent.js
+++ b/src/Objs/BlogPost/BlogPostComponent.js
@@ -1,11 +1,11 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 
-import BlogPostAuthor from "../../Components/BlogPost/BlogPostAuthor";
-import BlogPostMorePosts from "../../Components/BlogPost/BlogPostMorePosts";
-import BlogPostNavigation from "../../Components/BlogPost/BlogPostNavigation";
-import BlogPostTagList from "../../Components/BlogPost/BlogPostTagList";
-import SchemaDotOrg from "../../Components/SchemaDotOrg";
+import { BlogPostAuthor } from "../../Components/BlogPost/BlogPostAuthor";
+import { BlogPostMorePosts } from "../../Components/BlogPost/BlogPostMorePosts";
+import { BlogPostNavigation } from "../../Components/BlogPost/BlogPostNavigation";
+import { BlogPostTagList } from "../../Components/BlogPost/BlogPostTagList";
+import { SchemaDotOrg } from "../../Components/SchemaDotOrg";
 
 Scrivito.provideComponent("BlogPost", ({ page }) => (
   <div>

--- a/src/Objs/BlogPost/BlogPostEditingConfig.js
+++ b/src/Objs/BlogPost/BlogPostEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import blogPostObjIcon from "../../assets/images/blog_post_obj.svg";
-import SectionWidget from "../../Widgets/SectionWidget/SectionWidgetClass";
+import { SectionWidget } from "../../Widgets/SectionWidget/SectionWidgetClass";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,

--- a/src/Objs/BlogPost/BlogPostObjClass.js
+++ b/src/Objs/BlogPost/BlogPostObjClass.js
@@ -1,7 +1,7 @@
 import * as Scrivito from "scrivito";
-import metadataAttributes from "../_metadataAttributes";
+import { metadataAttributes } from "../_metadataAttributes";
 
-const BlogPost = Scrivito.provideObjClass("BlogPost", {
+export const BlogPost = Scrivito.provideObjClass("BlogPost", {
   attributes: {
     author: ["reference", { only: "Author" }],
     body: ["widgetlist", { only: "SectionWidget" }],
@@ -14,5 +14,3 @@ const BlogPost = Scrivito.provideObjClass("BlogPost", {
   },
   extractTextAttributes: ["body"],
 });
-
-export default BlogPost;

--- a/src/Objs/Download/DownloadObjClass.js
+++ b/src/Objs/Download/DownloadObjClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const Download = Scrivito.provideObjClass("Download", {
+export const Download = Scrivito.provideObjClass("Download", {
   attributes: {
     blob: "binary",
     tags: "stringlist",
@@ -8,5 +8,3 @@ const Download = Scrivito.provideObjClass("Download", {
   },
   extractTextAttributes: ["blob:text"],
 });
-
-export default Download;

--- a/src/Objs/Event/EventComponent.js
+++ b/src/Objs/Event/EventComponent.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import formatDate from "../../utils/formatDate";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
-import SchemaDotOrg from "../../Components/SchemaDotOrg";
+import { formatDate } from "../../utils/formatDate";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
+import { SchemaDotOrg } from "../../Components/SchemaDotOrg";
 
 Scrivito.provideComponent("Event", ({ page }) => (
   <div>

--- a/src/Objs/Event/EventEditingConfig.js
+++ b/src/Objs/Event/EventEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import eventObjIcon from "../../assets/images/event_obj.svg";
-import SectionWidget from "../../Widgets/SectionWidget/SectionWidgetClass";
+import { SectionWidget } from "../../Widgets/SectionWidget/SectionWidgetClass";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,

--- a/src/Objs/Event/EventObjClass.js
+++ b/src/Objs/Event/EventObjClass.js
@@ -1,7 +1,7 @@
 import * as Scrivito from "scrivito";
-import metadataAttributes from "../_metadataAttributes";
+import { metadataAttributes } from "../_metadataAttributes";
 
-const Event = Scrivito.provideObjClass("Event", {
+export const Event = Scrivito.provideObjClass("Event", {
   attributes: {
     body: ["widgetlist", { only: "SectionWidget" }],
     date: "date",
@@ -23,5 +23,3 @@ const Event = Scrivito.provideObjClass("Event", {
     "body",
   ],
 });
-
-export default Event;

--- a/src/Objs/Homepage/HomepageObjClass.js
+++ b/src/Objs/Homepage/HomepageObjClass.js
@@ -1,8 +1,8 @@
 import * as Scrivito from "scrivito";
-import defaultPageAttributes from "../_defaultPageAttributes";
-import metadataAttributes from "../_metadataAttributes";
+import { defaultPageAttributes } from "../_defaultPageAttributes";
+import { metadataAttributes } from "../_metadataAttributes";
 
-const Homepage = Scrivito.provideObjClass("Homepage", {
+export const Homepage = Scrivito.provideObjClass("Homepage", {
   attributes: {
     ...defaultPageAttributes,
     showAsLandingPage: "boolean",
@@ -23,5 +23,3 @@ const Homepage = Scrivito.provideObjClass("Homepage", {
   extractTextAttributes: ["navigationSection", "body"],
   onlyAsRoot: true,
 });
-
-export default Homepage;

--- a/src/Objs/Image/ImageObjClass.js
+++ b/src/Objs/Image/ImageObjClass.js
@@ -1,11 +1,9 @@
 import * as Scrivito from "scrivito";
 
-const Image = Scrivito.provideObjClass("Image", {
+export const Image = Scrivito.provideObjClass("Image", {
   attributes: {
     blob: "binary",
     tags: "stringlist",
     alternativeText: "string",
   },
 });
-
-export default Image;

--- a/src/Objs/Job/JobComponent.js
+++ b/src/Objs/Job/JobComponent.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import formatDate from "../../utils/formatDate";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
-import SchemaDotOrg from "../../Components/SchemaDotOrg";
+import { formatDate } from "../../utils/formatDate";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
+import { SchemaDotOrg } from "../../Components/SchemaDotOrg";
 
 Scrivito.provideComponent("Job", ({ page }) => (
   <div>

--- a/src/Objs/Job/JobEditingConfig.js
+++ b/src/Objs/Job/JobEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import jobObjIcon from "../../assets/images/job_obj.svg";
-import SectionWidget from "../../Widgets/SectionWidget/SectionWidgetClass";
+import { SectionWidget } from "../../Widgets/SectionWidget/SectionWidgetClass";
 import {
   metadataEditingConfigAttributes,
   metadataInitialContent,

--- a/src/Objs/Job/JobObjClass.js
+++ b/src/Objs/Job/JobObjClass.js
@@ -1,7 +1,7 @@
 import * as Scrivito from "scrivito";
-import metadataAttributes from "../_metadataAttributes";
+import { metadataAttributes } from "../_metadataAttributes";
 
-const Job = Scrivito.provideObjClass("Job", {
+export const Job = Scrivito.provideObjClass("Job", {
   attributes: {
     body: ["widgetlist", { only: "SectionWidget" }],
     image: ["reference", { only: ["Image"] }],
@@ -39,5 +39,3 @@ const Job = Scrivito.provideObjClass("Job", {
   },
   extractTextAttributes: ["body"],
 });
-
-export default Job;

--- a/src/Objs/LandingPage/LandingPageObjClass.js
+++ b/src/Objs/LandingPage/LandingPageObjClass.js
@@ -1,13 +1,11 @@
 import * as Scrivito from "scrivito";
-import metadataAttributes from "../_metadataAttributes";
-import defaultPageAttributes from "../_defaultPageAttributes";
+import { metadataAttributes } from "../_metadataAttributes";
+import { defaultPageAttributes } from "../_defaultPageAttributes";
 
-const LandingPage = Scrivito.provideObjClass("LandingPage", {
+export const LandingPage = Scrivito.provideObjClass("LandingPage", {
   attributes: {
     ...defaultPageAttributes,
     ...metadataAttributes,
   },
   extractTextAttributes: ["navigationSection", "body"],
 });
-
-export default LandingPage;

--- a/src/Objs/Page/PageObjClass.js
+++ b/src/Objs/Page/PageObjClass.js
@@ -1,8 +1,8 @@
 import * as Scrivito from "scrivito";
-import metadataAttributes from "../_metadataAttributes";
-import defaultPageAttributes from "../_defaultPageAttributes";
+import { metadataAttributes } from "../_metadataAttributes";
+import { defaultPageAttributes } from "../_defaultPageAttributes";
 
-const Page = Scrivito.provideObjClass("Page", {
+export const Page = Scrivito.provideObjClass("Page", {
   attributes: {
     ...defaultPageAttributes,
     childOrder: "referencelist",
@@ -10,5 +10,3 @@ const Page = Scrivito.provideObjClass("Page", {
   },
   extractTextAttributes: ["navigationSection", "body"],
 });
-
-export default Page;

--- a/src/Objs/Redirect/RedirectComponent.js
+++ b/src/Objs/Redirect/RedirectComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 
 class RedirectComponent extends React.Component {
   componentDidMount() {

--- a/src/Objs/Redirect/RedirectObjClass.js
+++ b/src/Objs/Redirect/RedirectObjClass.js
@@ -1,10 +1,8 @@
 import * as Scrivito from "scrivito";
 
-const Redirect = Scrivito.provideObjClass("Redirect", {
+export const Redirect = Scrivito.provideObjClass("Redirect", {
   attributes: {
     title: "string",
     link: "link",
   },
 });
-
-export default Redirect;

--- a/src/Objs/RedirectToUi/RedirectToUiObjClass.js
+++ b/src/Objs/RedirectToUi/RedirectToUiObjClass.js
@@ -1,7 +1,5 @@
 import * as Scrivito from "scrivito";
 
-const RedirectToUi = Scrivito.provideObjClass("RedirectToUi", {
+export const RedirectToUi = Scrivito.provideObjClass("RedirectToUi", {
   attributes: {},
 });
-
-export default RedirectToUi;

--- a/src/Objs/SearchResults/SearchInput.js
+++ b/src/Objs/SearchResults/SearchInput.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 
-class SearchInput extends React.Component {
+export class SearchInput extends React.Component {
   constructor(props) {
     super(props);
 
@@ -47,5 +47,3 @@ class SearchInput extends React.Component {
     Scrivito.navigateTo(() => Scrivito.currentPage(), { q: this.state.q });
   }
 }
-
-export default SearchInput;

--- a/src/Objs/SearchResults/SearchResultItem.js
+++ b/src/Objs/SearchResults/SearchResultItem.js
@@ -4,7 +4,7 @@ import fromNow from "moment-from-now";
 import Highlighter from "react-highlight-words";
 import { truncate } from "lodash-es";
 
-import isVideoObj from "../../utils/isVideoObj";
+import { isVideoObj } from "../../utils/isVideoObj";
 import "./SearchResultItem.scss";
 
 const PreviewImage = Scrivito.connect(({ item }) => {
@@ -38,7 +38,10 @@ const Details = Scrivito.connect(({ item }) => {
   return <small>{details.join(" // ")}</small>;
 });
 
-function SearchResultItem({ resultItem, q }) {
+export const SearchResultItem = Scrivito.connect(function SearchResultItem({
+  resultItem,
+  q,
+}) {
   const searchWords = q.split(/\s+/);
   const extractedText = Scrivito.extractText(resultItem, { length: 220 });
   const textToHighlight = truncate(extractedText, {
@@ -78,6 +81,4 @@ function SearchResultItem({ resultItem, q }) {
       </div>
     </div>
   );
-}
-
-export default Scrivito.connect(SearchResultItem);
+});

--- a/src/Objs/SearchResults/SearchResultsComponent.js
+++ b/src/Objs/SearchResults/SearchResultsComponent.js
@@ -1,9 +1,9 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import ShowMoreButton from "./ShowMoreButton";
-import SearchInput from "./SearchInput";
-import SearchResultItem from "./SearchResultItem";
-import SearchResultsTagList from "./SearchResultsTagList";
+import { ShowMoreButton } from "./ShowMoreButton";
+import { SearchInput } from "./SearchInput";
+import { SearchResultItem } from "./SearchResultItem";
+import { SearchResultsTagList } from "./SearchResultsTagList";
 
 class SearchResultsComponent extends React.Component {
   constructor(props) {

--- a/src/Objs/SearchResults/SearchResultsObjClass.js
+++ b/src/Objs/SearchResults/SearchResultsObjClass.js
@@ -1,12 +1,10 @@
 import * as Scrivito from "scrivito";
-import metadataAttributes from "../_metadataAttributes";
+import { metadataAttributes } from "../_metadataAttributes";
 
-const SearchResults = Scrivito.provideObjClass("SearchResults", {
+export const SearchResults = Scrivito.provideObjClass("SearchResults", {
   attributes: {
     title: "string",
     navigationBackgroundImage: ["reference", { only: ["Image"] }],
     ...metadataAttributes,
   },
 });
-
-export default SearchResults;

--- a/src/Objs/SearchResults/SearchResultsTagList.js
+++ b/src/Objs/SearchResults/SearchResultsTagList.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import TagList from "../../Components/TagList";
+import { TagList } from "../../Components/TagList";
 
-function SearchResultsTagList({ tags, params }) {
+export function SearchResultsTagList({ tags, params }) {
   return (
     <TagList
       tags={tags}
@@ -17,5 +17,3 @@ function SearchResultsTagList({ tags, params }) {
     />
   );
 }
-
-export default SearchResultsTagList;

--- a/src/Objs/SearchResults/ShowMoreButton.js
+++ b/src/Objs/SearchResults/ShowMoreButton.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
-function ShowMoreButton({ currentMaxItems, totalCount, onClick }) {
+export function ShowMoreButton({ currentMaxItems, totalCount, onClick }) {
   if (currentMaxItems >= totalCount) return null;
 
   return (
@@ -17,5 +17,3 @@ function ShowMoreButton({ currentMaxItems, totalCount, onClick }) {
   );
 }
 /* eslint-enable jsx-a11y/anchor-is-valid */
-
-export default ShowMoreButton;

--- a/src/Objs/Video/VideoObjClass.js
+++ b/src/Objs/Video/VideoObjClass.js
@@ -1,10 +1,8 @@
 import * as Scrivito from "scrivito";
 
-const Video = Scrivito.provideObjClass("Video", {
+export const Video = Scrivito.provideObjClass("Video", {
   attributes: {
     blob: "binary",
     tags: "stringlist",
   },
 });
-
-export default Video;

--- a/src/Objs/_defaultPageAttributes.js
+++ b/src/Objs/_defaultPageAttributes.js
@@ -1,4 +1,4 @@
-const defaultPageAttributes = {
+export const defaultPageAttributes = {
   body: ["widgetlist", { only: "SectionWidget" }],
   navigationBackgroundImage: ["reference", { only: ["Image", "Video"] }],
   navigationBackgroundImageGradient: "boolean",
@@ -11,5 +11,3 @@ const defaultPageAttributes = {
   navigationSection: "widgetlist",
   title: "string",
 };
-
-export default defaultPageAttributes;

--- a/src/Objs/_defaultPageEditingConfig.js
+++ b/src/Objs/_defaultPageEditingConfig.js
@@ -1,5 +1,5 @@
-import HeadlineWidget from "../Widgets/HeadlineWidget/HeadlineWidgetClass";
-import SectionWidget from "../Widgets/SectionWidget/SectionWidgetClass";
+import { HeadlineWidget } from "../Widgets/HeadlineWidget/HeadlineWidgetClass";
+import { SectionWidget } from "../Widgets/SectionWidget/SectionWidgetClass";
 
 export const defaultPageEditingConfigAttributes = {
   title: {

--- a/src/Objs/_metadataAttributes.js
+++ b/src/Objs/_metadataAttributes.js
@@ -1,4 +1,4 @@
-const metadataAttributes = {
+export const metadataAttributes = {
   // Meta tags
   metaDataDescription: "string",
   robotsIndex: "boolean",
@@ -12,5 +12,3 @@ const metadataAttributes = {
   ogImage: ["reference", { only: ["Image"] }],
   ogTitle: "string",
 };
-
-export default metadataAttributes;

--- a/src/Objs/_metadataEditingConfig.js
+++ b/src/Objs/_metadataEditingConfig.js
@@ -1,4 +1,4 @@
-import SocialCardsTab from "../Components/ScrivitoExtensions/SocialCardsTab";
+import { SocialCardsTab } from "../Components/ScrivitoExtensions/SocialCardsTab";
 
 export const metadataEditingConfigAttributes = {
   metaDataDescription: {

--- a/src/Widgets/AddressWidget/AddressWidgetClass.js
+++ b/src/Widgets/AddressWidget/AddressWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const AddressWidget = Scrivito.provideWidgetClass("AddressWidget", {
+export const AddressWidget = Scrivito.provideWidgetClass("AddressWidget", {
   attributes: {
     showLogo: "boolean",
     showBorderBottom: "boolean",
@@ -29,5 +29,3 @@ const AddressWidget = Scrivito.provideWidgetClass("AddressWidget", {
     "email",
   ],
 });
-
-export default AddressWidget;

--- a/src/Widgets/AddressWidget/AddressWidgetComponent.js
+++ b/src/Widgets/AddressWidget/AddressWidgetComponent.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
-import SchemaDotOrg from "../../Components/SchemaDotOrg";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
+import { SchemaDotOrg } from "../../Components/SchemaDotOrg";
 
 Scrivito.provideComponent("AddressWidget", ({ widget }) => (
   <div>

--- a/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetClass.js
+++ b/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetClass.js
@@ -1,11 +1,12 @@
 import * as Scrivito from "scrivito";
 
-const BlogOverviewWidget = Scrivito.provideWidgetClass("BlogOverviewWidget", {
-  attributes: {
-    maxItems: "integer",
-    author: ["reference", { only: "Author" }],
-    tags: "stringlist",
-  },
-});
-
-export default BlogOverviewWidget;
+export const BlogOverviewWidget = Scrivito.provideWidgetClass(
+  "BlogOverviewWidget",
+  {
+    attributes: {
+      maxItems: "integer",
+      author: ["reference", { only: "Author" }],
+      tags: "stringlist",
+    },
+  }
+);

--- a/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
+++ b/src/Widgets/BlogOverviewWidget/BlogOverviewWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import BlogPostPreviewList from "../../Components/BlogPost/BlogPostPreviewList";
+import { BlogPostPreviewList } from "../../Components/BlogPost/BlogPostPreviewList";
 
 Scrivito.provideComponent("BlogOverviewWidget", ({ widget }) => {
   let { tag } = Scrivito.currentPageParams();

--- a/src/Widgets/BoxWidget/BoxWidgetClass.js
+++ b/src/Widgets/BoxWidget/BoxWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const BoxWidget = Scrivito.provideWidgetClass("BoxWidget", {
+export const BoxWidget = Scrivito.provideWidgetClass("BoxWidget", {
   attributes: {
     body: "widgetlist",
     boxStyle: ["enum", { values: ["transparent", "white"] }],
@@ -8,5 +8,3 @@ const BoxWidget = Scrivito.provideWidgetClass("BoxWidget", {
   },
   extractTextAttributes: ["body"],
 });
-
-export default BoxWidget;

--- a/src/Widgets/ButtonWidget/ButtonWidgetClass.js
+++ b/src/Widgets/ButtonWidget/ButtonWidgetClass.js
@@ -1,11 +1,9 @@
 import * as Scrivito from "scrivito";
 
-const ButtonWidget = Scrivito.provideWidgetClass("ButtonWidget", {
+export const ButtonWidget = Scrivito.provideWidgetClass("ButtonWidget", {
   attributes: {
     target: "link",
     alignment: ["enum", { values: ["left", "center", "right", "block"] }],
     style: ["enum", { values: ["btn-primary", "btn-clear"] }],
   },
 });
-
-export default ButtonWidget;

--- a/src/Widgets/ButtonWidget/ButtonWidgetComponent.js
+++ b/src/Widgets/ButtonWidget/ButtonWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 import { WrapIfClassName } from "../../Components/WrapIfClassName";
 import { alignmentClassName } from "../../utils/alignmentClassName";
 

--- a/src/Widgets/CarouselWidget/CarouselWidgetClass.js
+++ b/src/Widgets/CarouselWidget/CarouselWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const CarouselWidget = Scrivito.provideWidgetClass("CarouselWidget", {
+export const CarouselWidget = Scrivito.provideWidgetClass("CarouselWidget", {
   attributes: {
     images: ["referencelist", { only: ["Image"] }],
     showDescription: "boolean",
@@ -9,5 +9,3 @@ const CarouselWidget = Scrivito.provideWidgetClass("CarouselWidget", {
   },
   extractTextAttributes: ["description"],
 });
-
-export default CarouselWidget;

--- a/src/Widgets/CarouselWidget/CarouselWidgetComponent.js
+++ b/src/Widgets/CarouselWidget/CarouselWidgetComponent.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 import Carousel from "react-bootstrap/Carousel";
 
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 import "./CarouselWidget.scss";
 
 Scrivito.provideComponent("CarouselWidget", ({ widget }) => {

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetClass.js
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const ColumnContainerWidget = Scrivito.provideWidgetClass(
+export const ColumnContainerWidget = Scrivito.provideWidgetClass(
   "ColumnContainerWidget",
   {
     attributes: {
@@ -10,5 +10,3 @@ const ColumnContainerWidget = Scrivito.provideWidgetClass(
     extractTextAttributes: ["columns"],
   }
 );
-
-export default ColumnContainerWidget;

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetComponent.js
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 
 Scrivito.provideComponent("ColumnContainerWidget", ({ widget }) => {
   const columns = widget.get("columns");

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetEditingConfig.js
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetEditingConfig.js
@@ -1,7 +1,7 @@
 import * as Scrivito from "scrivito";
 import columnContainerWidgetIcon from "../../assets/images/column_container_widget.svg";
-import ColumnsEditorTab from "../../Components/ScrivitoExtensions/ColumnsEditorTab";
-import ColumnWidget from "../ColumnWidget/ColumnWidgetClass";
+import { ColumnsEditorTab } from "../../Components/ScrivitoExtensions/ColumnsEditorTab";
+import { ColumnWidget } from "../ColumnWidget/ColumnWidgetClass";
 
 Scrivito.provideEditingConfig("ColumnContainerWidget", {
   title: "Columns",

--- a/src/Widgets/ColumnWidget/ColumnWidgetClass.js
+++ b/src/Widgets/ColumnWidget/ColumnWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const ColumnWidget = Scrivito.provideWidgetClass("ColumnWidget", {
+export const ColumnWidget = Scrivito.provideWidgetClass("ColumnWidget", {
   onlyInside: "ColumnContainerWidget",
   attributes: {
     colSize: "integer",
@@ -8,5 +8,3 @@ const ColumnWidget = Scrivito.provideWidgetClass("ColumnWidget", {
   },
   extractTextAttributes: ["content"],
 });
-
-export default ColumnWidget;

--- a/src/Widgets/ContactFormWidget/ContactFormWidgetClass.js
+++ b/src/Widgets/ContactFormWidget/ContactFormWidgetClass.js
@@ -1,11 +1,12 @@
 import * as Scrivito from "scrivito";
 
-const ContactFormWidget = Scrivito.provideWidgetClass("ContactFormWidget", {
-  attributes: {
-    agreementText: "string",
-    buttonText: "string",
-    backgroundColor: ["enum", { values: ["white", "transparent"] }],
-  },
-});
-
-export default ContactFormWidget;
+export const ContactFormWidget = Scrivito.provideWidgetClass(
+  "ContactFormWidget",
+  {
+    attributes: {
+      agreementText: "string",
+      buttonText: "string",
+      backgroundColor: ["enum", { values: ["white", "transparent"] }],
+    },
+  }
+);

--- a/src/Widgets/DividerWidget/DividerWidgetClass.js
+++ b/src/Widgets/DividerWidget/DividerWidgetClass.js
@@ -1,9 +1,7 @@
 import * as Scrivito from "scrivito";
 
-const DividerWidget = Scrivito.provideWidgetClass("DividerWidget", {
+export const DividerWidget = Scrivito.provideWidgetClass("DividerWidget", {
   attributes: {
     showLogo: "boolean",
   },
 });
-
-export default DividerWidget;

--- a/src/Widgets/EventOverviewWidget/EventOverviewWidgetClass.js
+++ b/src/Widgets/EventOverviewWidget/EventOverviewWidgetClass.js
@@ -1,11 +1,12 @@
 import * as Scrivito from "scrivito";
 
-const EventOverviewWidget = Scrivito.provideWidgetClass("EventOverviewWidget", {
-  attributes: {
-    maxItems: "integer",
-    showTags: "boolean",
-    tags: "stringlist",
-  },
-});
-
-export default EventOverviewWidget;
+export const EventOverviewWidget = Scrivito.provideWidgetClass(
+  "EventOverviewWidget",
+  {
+    attributes: {
+      maxItems: "integer",
+      showTags: "boolean",
+      tags: "stringlist",
+    },
+  }
+);

--- a/src/Widgets/EventOverviewWidget/EventOverviewWidgetComponent.js
+++ b/src/Widgets/EventOverviewWidget/EventOverviewWidgetComponent.js
@@ -1,9 +1,9 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import Event from "../../Objs/Event/EventObjClass";
-import formatDate from "../../utils/formatDate";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
-import TagList from "../../Components/TagList";
+import { Event } from "../../Objs/Event/EventObjClass";
+import { formatDate } from "../../utils/formatDate";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
+import { TagList } from "../../Components/TagList";
 
 class EventOverviewWidgetComponent extends React.Component {
   constructor(props) {

--- a/src/Widgets/FactWidget/FactWidgetClass.js
+++ b/src/Widgets/FactWidget/FactWidgetClass.js
@@ -1,11 +1,9 @@
 import * as Scrivito from "scrivito";
 
-const FactWidget = Scrivito.provideWidgetClass("FactWidget", {
+export const FactWidget = Scrivito.provideWidgetClass("FactWidget", {
   attributes: {
     key: "string",
     value: "string",
   },
   extractTextAttributes: ["key", "value"],
 });
-
-export default FactWidget;

--- a/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetClass.js
+++ b/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetClass.js
@@ -1,12 +1,13 @@
 import * as Scrivito from "scrivito";
 
-const FeaturePanelWidget = Scrivito.provideWidgetClass("FeaturePanelWidget", {
-  attributes: {
-    icon: "string",
-    headline: "string",
-    description: "string",
-  },
-  extractTextAttributes: ["headline", "description"],
-});
-
-export default FeaturePanelWidget;
+export const FeaturePanelWidget = Scrivito.provideWidgetClass(
+  "FeaturePanelWidget",
+  {
+    attributes: {
+      icon: "string",
+      headline: "string",
+      description: "string",
+    },
+    extractTextAttributes: ["headline", "description"],
+  }
+);

--- a/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetEditingConfig.js
+++ b/src/Widgets/FeaturePanelWidget/FeaturePanelWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import featurePanelWidgetIcon from "../../assets/images/feature_panel_widget.svg";
-import IconEditorTab from "../../Components/ScrivitoExtensions/IconEditorTab";
+import { IconEditorTab } from "../../Components/ScrivitoExtensions/IconEditorTab";
 
 Scrivito.provideEditingConfig("FeaturePanelWidget", {
   title: "Feature Panel",

--- a/src/Widgets/GalleryWidget/GalleryWidgetClass.js
+++ b/src/Widgets/GalleryWidget/GalleryWidgetClass.js
@@ -1,9 +1,7 @@
 import * as Scrivito from "scrivito";
 
-const GalleryWidget = Scrivito.provideWidgetClass("GalleryWidget", {
+export const GalleryWidget = Scrivito.provideWidgetClass("GalleryWidget", {
   attributes: {
     images: ["referencelist", { only: ["Image"] }],
   },
 });
-
-export default GalleryWidget;

--- a/src/Widgets/GalleryWidget/GalleryWidgetComponent.js
+++ b/src/Widgets/GalleryWidget/GalleryWidgetComponent.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 import Slider from "react-slick";
 
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 import "./GalleryWidget.scss";
 
 Scrivito.provideComponent("GalleryWidget", ({ widget }) => {

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetClass.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetClass.js
@@ -1,40 +1,41 @@
 import * as Scrivito from "scrivito";
 
-const GoogleMapsWidget = Scrivito.provideWidgetClass("GoogleMapsWidget", {
-  attributes: {
-    address: "string",
-    mapType: ["enum", { values: ["interactive", "static"] }],
-    zoom: [
-      "enum",
-      {
-        values: [
-          "1",
-          "2",
-          "3",
-          "4",
-          "5",
-          "6",
-          "7",
-          "8",
-          "9",
-          "10",
-          "11",
-          "12",
-          "13",
-          "14",
-          "15",
-          "16",
-          "17",
-          "18",
-          "19",
-          "20",
-        ],
-      },
-    ],
-    showWidgets: "boolean",
-    content: "widgetlist",
-  },
-  extractTextAttributes: ["content"],
-});
-
-export default GoogleMapsWidget;
+export const GoogleMapsWidget = Scrivito.provideWidgetClass(
+  "GoogleMapsWidget",
+  {
+    attributes: {
+      address: "string",
+      mapType: ["enum", { values: ["interactive", "static"] }],
+      zoom: [
+        "enum",
+        {
+          values: [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+          ],
+        },
+      ],
+      showWidgets: "boolean",
+      content: "widgetlist",
+    },
+    extractTextAttributes: ["content"],
+  }
+);

--- a/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
+++ b/src/Widgets/GoogleMapsWidget/GoogleMapsWidgetComponent.js
@@ -2,8 +2,8 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 import useResizeObserver from "use-resize-observer";
 
-import googleMapsApiKey from "../../utils/googleMapsApiKey";
-import googleMapsImageUrl from "../../utils/googleMapsImageUrl";
+import { googleMapsApiKey } from "../../utils/googleMapsApiKey";
+import { googleMapsImageUrl } from "../../utils/googleMapsImageUrl";
 import "./GoogleMapsWidget.scss";
 
 const maxWidth = 640;

--- a/src/Widgets/GroupWidget/GroupWidgetClass.js
+++ b/src/Widgets/GroupWidget/GroupWidgetClass.js
@@ -1,10 +1,8 @@
 import * as Scrivito from "scrivito";
 
-const GroupWidget = Scrivito.provideWidgetClass("GroupWidget", {
+export const GroupWidget = Scrivito.provideWidgetClass("GroupWidget", {
   attributes: {
     content: "widgetlist",
   },
   extractTextAttributes: ["content"],
 });
-
-export default GroupWidget;

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetClass.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const HeadlineWidget = Scrivito.provideWidgetClass("HeadlineWidget", {
+export const HeadlineWidget = Scrivito.provideWidgetClass("HeadlineWidget", {
   attributes: {
     headline: "string",
     level: ["enum", { values: ["h1", "h2", "h3", "h4", "h5", "h6"] }],
@@ -11,5 +11,3 @@ const HeadlineWidget = Scrivito.provideWidgetClass("HeadlineWidget", {
   },
   extractTextAttributes: ["headline"],
 });
-
-export default HeadlineWidget;

--- a/src/Widgets/IconContainerWidget/IconContainerWidgetClass.js
+++ b/src/Widgets/IconContainerWidget/IconContainerWidgetClass.js
@@ -1,9 +1,10 @@
 import * as Scrivito from "scrivito";
 
-const IconContainerWidget = Scrivito.provideWidgetClass("IconContainerWidget", {
-  attributes: {
-    iconList: ["widgetlist", { only: "IconWidget" }],
-  },
-});
-
-export default IconContainerWidget;
+export const IconContainerWidget = Scrivito.provideWidgetClass(
+  "IconContainerWidget",
+  {
+    attributes: {
+      iconList: ["widgetlist", { only: "IconWidget" }],
+    },
+  }
+);

--- a/src/Widgets/IconContainerWidget/IconContainerWidgetComponent.js
+++ b/src/Widgets/IconContainerWidget/IconContainerWidgetComponent.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import IconComponent from "../../Components/Icon";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { IconComponent } from "../../Components/Icon";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 
 Scrivito.provideComponent("IconContainerWidget", ({ widget }) => {
   const icons = widget.get("iconList");

--- a/src/Widgets/IconContainerWidget/IconContainerWidgetEditingConfig.js
+++ b/src/Widgets/IconContainerWidget/IconContainerWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import iconContainerWidgetIcon from "../../assets/images/icon_container_widget.svg";
-import IconWidget from "../IconWidget/IconWidgetClass";
+import { IconWidget } from "../IconWidget/IconWidgetClass";
 
 Scrivito.provideEditingConfig("IconContainerWidget", {
   title: "Icon List",

--- a/src/Widgets/IconWidget/IconWidgetClass.js
+++ b/src/Widgets/IconWidget/IconWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const IconWidget = Scrivito.provideWidgetClass("IconWidget", {
+export const IconWidget = Scrivito.provideWidgetClass("IconWidget", {
   attributes: {
     icon: "string",
     size: [
@@ -11,5 +11,3 @@ const IconWidget = Scrivito.provideWidgetClass("IconWidget", {
     link: "link",
   },
 });
-
-export default IconWidget;

--- a/src/Widgets/IconWidget/IconWidgetComponent.js
+++ b/src/Widgets/IconWidget/IconWidgetComponent.js
@@ -1,21 +1,21 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import IconComponent from "../../Components/Icon";
+import { IconComponent } from "../../Components/Icon";
 import { WrapIfClassName } from "../../Components/WrapIfClassName";
 import { alignmentClassName } from "../../utils/alignmentClassName";
 
-function IconWidgetComponent({ widget }) {
-  return (
-    <WrapIfClassName className={alignmentClassName(widget.get("alignment"))}>
-      <IconComponent
-        icon={widget.get("icon")}
-        size={widget.get("size")}
-        link={widget.get("link")}
-      />
-    </WrapIfClassName>
-  );
-}
+export const IconWidgetComponent = Scrivito.connect(
+  function IconWidgetComponent({ widget }) {
+    return (
+      <WrapIfClassName className={alignmentClassName(widget.get("alignment"))}>
+        <IconComponent
+          icon={widget.get("icon")}
+          size={widget.get("size")}
+          link={widget.get("link")}
+        />
+      </WrapIfClassName>
+    );
+  }
+);
 
 Scrivito.provideComponent("IconWidget", IconWidgetComponent);
-
-export default Scrivito.connect(IconWidgetComponent);

--- a/src/Widgets/IconWidget/IconWidgetEditingConfig.js
+++ b/src/Widgets/IconWidget/IconWidgetEditingConfig.js
@@ -1,5 +1,5 @@
 import * as Scrivito from "scrivito";
-import IconEditorTab from "../../Components/ScrivitoExtensions/IconEditorTab";
+import { IconEditorTab } from "../../Components/ScrivitoExtensions/IconEditorTab";
 import iconWidgetIcon from "../../assets/images/icon_widget.svg";
 
 Scrivito.provideEditingConfig("IconWidget", {

--- a/src/Widgets/ImageWidget/ImageWidgetClass.js
+++ b/src/Widgets/ImageWidget/ImageWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const ImageWidget = Scrivito.provideWidgetClass("ImageWidget", {
+export const ImageWidget = Scrivito.provideWidgetClass("ImageWidget", {
   attributes: {
     image: ["reference", { only: "Image" }],
     alignment: ["enum", { values: ["left", "center", "right"] }],
@@ -21,5 +21,3 @@ const ImageWidget = Scrivito.provideWidgetClass("ImageWidget", {
     ],
   },
 });
-
-export default ImageWidget;

--- a/src/Widgets/ImageWidget/ImageWidgetComponent.js
+++ b/src/Widgets/ImageWidget/ImageWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import AnimateOnReveal from "../../Components/AnimateOnReveal";
+import { AnimateOnReveal } from "../../Components/AnimateOnReveal";
 import { alignmentClassName } from "../../utils/alignmentClassName";
 
 Scrivito.provideComponent("ImageWidget", ({ widget }) => {

--- a/src/Widgets/JobOverviewWidget/JobOverviewWidgetClass.js
+++ b/src/Widgets/JobOverviewWidget/JobOverviewWidgetClass.js
@@ -1,9 +1,10 @@
 import * as Scrivito from "scrivito";
 
-const JobOverviewWidget = Scrivito.provideWidgetClass("JobOverviewWidget", {
-  attributes: {
-    locationLocality: "string",
-  },
-});
-
-export default JobOverviewWidget;
+export const JobOverviewWidget = Scrivito.provideWidgetClass(
+  "JobOverviewWidget",
+  {
+    attributes: {
+      locationLocality: "string",
+    },
+  }
+);

--- a/src/Widgets/JobOverviewWidget/JobOverviewWidgetComponent.js
+++ b/src/Widgets/JobOverviewWidget/JobOverviewWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 
 Scrivito.provideComponent("JobOverviewWidget", ({ widget }) => {
   let jobsSearch = Scrivito.getClass("Job").all();

--- a/src/Widgets/LinkContainerWidget/LinkContainerWidgetClass.js
+++ b/src/Widgets/LinkContainerWidget/LinkContainerWidgetClass.js
@@ -1,10 +1,11 @@
 import * as Scrivito from "scrivito";
 
-const LinkContainerWidget = Scrivito.provideWidgetClass("LinkContainerWidget", {
-  attributes: {
-    headline: "string",
-    links: ["widgetlist", { only: "LinkWidget" }],
-  },
-});
-
-export default LinkContainerWidget;
+export const LinkContainerWidget = Scrivito.provideWidgetClass(
+  "LinkContainerWidget",
+  {
+    attributes: {
+      headline: "string",
+      links: ["widgetlist", { only: "LinkWidget" }],
+    },
+  }
+);

--- a/src/Widgets/LinkContainerWidget/LinkContainerWidgetComponent.js
+++ b/src/Widgets/LinkContainerWidget/LinkContainerWidgetComponent.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 import "./LinkContainerWidget.scss";
 
 Scrivito.provideComponent("LinkContainerWidget", ({ widget }) => (

--- a/src/Widgets/LinkContainerWidget/LinkContainerWidgetEditingConfig.js
+++ b/src/Widgets/LinkContainerWidget/LinkContainerWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import linkListWidgetIcon from "../../assets/images/link_list_widget.svg";
-import LinkWidget from "../LinkWidget/LinkWidgetClass";
+import { LinkWidget } from "../LinkWidget/LinkWidgetClass";
 
 Scrivito.provideEditingConfig("LinkContainerWidget", {
   title: "Link List",

--- a/src/Widgets/LinkWidget/LinkWidgetClass.js
+++ b/src/Widgets/LinkWidget/LinkWidgetClass.js
@@ -1,10 +1,8 @@
 import * as Scrivito from "scrivito";
 
-const LinkWidget = Scrivito.provideWidgetClass("LinkWidget", {
+export const LinkWidget = Scrivito.provideWidgetClass("LinkWidget", {
   onlyInside: "LinkContainerWidget",
   attributes: {
     link: "link",
   },
 });
-
-export default LinkWidget;

--- a/src/Widgets/LinkWidget/LinkWidgetComponent.js
+++ b/src/Widgets/LinkWidget/LinkWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 
 Scrivito.provideComponent("LinkWidget", ({ widget }) => {
   const link = widget.get("link");

--- a/src/Widgets/PriceWidget/PriceWidgetClass.js
+++ b/src/Widgets/PriceWidget/PriceWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const PriceWidget = Scrivito.provideWidgetClass("PriceWidget", {
+export const PriceWidget = Scrivito.provideWidgetClass("PriceWidget", {
   onlyInside: "TableRowWidget",
   attributes: {
     currency: "string",
@@ -9,5 +9,3 @@ const PriceWidget = Scrivito.provideWidgetClass("PriceWidget", {
   },
   extractTextAttributes: ["price", "currency", "period"],
 });
-
-export default PriceWidget;

--- a/src/Widgets/PricingSpecWidget/PricingSpecWidgetClass.js
+++ b/src/Widgets/PricingSpecWidget/PricingSpecWidgetClass.js
@@ -1,12 +1,13 @@
 import * as Scrivito from "scrivito";
 
-const PricingSpecWidget = Scrivito.provideWidgetClass("PricingSpecWidget", {
-  onlyInside: "PricingWidget",
-  attributes: {
-    variable: "string",
-    unit: "string",
-  },
-  extractTextAttributes: ["variable", "unit"],
-});
-
-export default PricingSpecWidget;
+export const PricingSpecWidget = Scrivito.provideWidgetClass(
+  "PricingSpecWidget",
+  {
+    onlyInside: "PricingWidget",
+    attributes: {
+      variable: "string",
+      unit: "string",
+    },
+    extractTextAttributes: ["variable", "unit"],
+  }
+);

--- a/src/Widgets/PricingWidget/PricingWidgetClass.js
+++ b/src/Widgets/PricingWidget/PricingWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const PricingWidget = Scrivito.provideWidgetClass("PricingWidget", {
+export const PricingWidget = Scrivito.provideWidgetClass("PricingWidget", {
   attributes: {
     currency: "string",
 
@@ -35,5 +35,3 @@ const PricingWidget = Scrivito.provideWidgetClass("PricingWidget", {
     "largePlanSpecs",
   ],
 });
-
-export default PricingWidget;

--- a/src/Widgets/PricingWidget/PricingWidgetEditingConfig.js
+++ b/src/Widgets/PricingWidget/PricingWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import pricingWidgetIcon from "../../assets/images/pricing_widget.svg";
-import PricingSpecWidget from "../PricingSpecWidget/PricingSpecWidgetClass";
+import { PricingSpecWidget } from "../PricingSpecWidget/PricingSpecWidgetClass";
 
 Scrivito.provideEditingConfig("PricingWidget", {
   title: "Pricing",

--- a/src/Widgets/SectionWidget/SectionWidgetClass.js
+++ b/src/Widgets/SectionWidget/SectionWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const SectionWidget = Scrivito.provideWidgetClass("SectionWidget", {
+export const SectionWidget = Scrivito.provideWidgetClass("SectionWidget", {
   attributes: {
     content: "widgetlist",
     useFullWidth: "boolean",
@@ -24,5 +24,3 @@ const SectionWidget = Scrivito.provideWidgetClass("SectionWidget", {
   },
   extractTextAttributes: ["content"],
 });
-
-export default SectionWidget;

--- a/src/Widgets/SpaceWidget/SpaceWidgetClass.js
+++ b/src/Widgets/SpaceWidget/SpaceWidgetClass.js
@@ -1,9 +1,7 @@
 import * as Scrivito from "scrivito";
 
-const SpaceWidget = Scrivito.provideWidgetClass("SpaceWidget", {
+export const SpaceWidget = Scrivito.provideWidgetClass("SpaceWidget", {
   attributes: {
     size: "float",
   },
 });
-
-export default SpaceWidget;

--- a/src/Widgets/TableRowWidget/TableRowWidgetClass.js
+++ b/src/Widgets/TableRowWidget/TableRowWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const TableRowWidget = Scrivito.provideWidgetClass("TableRowWidget", {
+export const TableRowWidget = Scrivito.provideWidgetClass("TableRowWidget", {
   attributes: {
     cell1: "string",
     cell2: [
@@ -19,5 +19,3 @@ const TableRowWidget = Scrivito.provideWidgetClass("TableRowWidget", {
   onlyInside: "TableWidget",
   extractTextAttributes: ["cell1", "cell2", "cell3", "cell4"],
 });
-
-export default TableRowWidget;

--- a/src/Widgets/TableRowWidget/TableRowWidgetComponent.js
+++ b/src/Widgets/TableRowWidget/TableRowWidgetComponent.js
@@ -27,6 +27,6 @@ function PlainTableRowWidgetComponent({ widget, header2, header3, header4 }) {
   );
 }
 
-const TableRowWidgetComponent = Scrivito.connect(PlainTableRowWidgetComponent);
-
-export default TableRowWidgetComponent;
+export const TableRowWidgetComponent = Scrivito.connect(
+  PlainTableRowWidgetComponent
+);

--- a/src/Widgets/TableWidget/TableWidgetClass.js
+++ b/src/Widgets/TableWidget/TableWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const TableWidget = Scrivito.provideWidgetClass("TableWidget", {
+export const TableWidget = Scrivito.provideWidgetClass("TableWidget", {
   attributes: {
     rows: ["widgetlist", { only: "TableRowWidget" }],
     summaryRows: ["widgetlist", { only: "TableRowWidget" }],
@@ -10,5 +10,3 @@ const TableWidget = Scrivito.provideWidgetClass("TableWidget", {
     header4: "string",
   },
 });
-
-export default TableWidget;

--- a/src/Widgets/TableWidget/TableWidgetComponent.js
+++ b/src/Widgets/TableWidget/TableWidgetComponent.js
@@ -1,9 +1,9 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 
-import placeholderCss from "../../utils/placeholderCss";
-import TableRowWidget from "../TableRowWidget/TableRowWidgetClass";
-import TableRowWidgetComponent from "../TableRowWidget/TableRowWidgetComponent";
+import { placeholderCss } from "../../utils/placeholderCss";
+import { TableRowWidget } from "../TableRowWidget/TableRowWidgetClass";
+import { TableRowWidgetComponent } from "../TableRowWidget/TableRowWidgetComponent";
 import "./TableWidget.scss";
 
 Scrivito.provideComponent("TableWidget", ({ widget }) => (

--- a/src/Widgets/TableWidget/TableWidgetEditingConfig.js
+++ b/src/Widgets/TableWidget/TableWidgetEditingConfig.js
@@ -1,9 +1,9 @@
 import * as Scrivito from "scrivito";
-import IconWidget from "../IconWidget/IconWidgetClass";
-import PriceWidget from "../PriceWidget/PriceWidgetClass";
-import TableRowWidget from "../TableRowWidget/TableRowWidgetClass";
+import { IconWidget } from "../IconWidget/IconWidgetClass";
+import { PriceWidget } from "../PriceWidget/PriceWidgetClass";
+import { TableRowWidget } from "../TableRowWidget/TableRowWidgetClass";
 import tableWidgetIcon from "../../assets/images/table_widget.svg";
-import TextWidget from "../TextWidget/TextWidgetClass";
+import { TextWidget } from "../TextWidget/TextWidgetClass";
 
 Scrivito.provideEditingConfig("TableWidget", {
   title: "Table",

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetClass.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const TestimonialSliderWidget = Scrivito.provideWidgetClass(
+export const TestimonialSliderWidget = Scrivito.provideWidgetClass(
   "TestimonialSliderWidget",
   {
     attributes: {
@@ -8,5 +8,3 @@ const TestimonialSliderWidget = Scrivito.provideWidgetClass(
     },
   }
 );
-
-export default TestimonialSliderWidget;

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetComponent.js
@@ -2,9 +2,9 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 import Slider from "react-slick";
 
-import placeholderCss from "../../utils/placeholderCss";
-import TestimonialWidget from "../TestimonialWidget/TestimonialWidgetClass";
-import isImage from "../../utils/isImage";
+import { placeholderCss } from "../../utils/placeholderCss";
+import { TestimonialWidget } from "../TestimonialWidget/TestimonialWidgetClass";
+import { isImage } from "../../utils/isImage";
 import "./TestimonialSliderWidget.scss";
 
 Scrivito.provideComponent("TestimonialSliderWidget", ({ widget }) => {

--- a/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetEditingConfig.js
+++ b/src/Widgets/TestimonialSliderWidget/TestimonialSliderWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import testimonialSliderWidgetIcon from "../../assets/images/testimonial_slider_widget.svg";
-import TestimonialWidget from "../TestimonialWidget/TestimonialWidgetClass";
+import { TestimonialWidget } from "../TestimonialWidget/TestimonialWidgetClass";
 
 Scrivito.provideEditingConfig("TestimonialSliderWidget", {
   title: "Testimonial Slider",

--- a/src/Widgets/TestimonialWidget/TestimonialWidgetClass.js
+++ b/src/Widgets/TestimonialWidget/TestimonialWidgetClass.js
@@ -1,13 +1,14 @@
 import * as Scrivito from "scrivito";
 
-const TestimonialWidget = Scrivito.provideWidgetClass("TestimonialWidget", {
-  onlyInside: "TestimonialSliderWidget",
-  attributes: {
-    testimonial: "string",
-    author: "string",
-    authorImage: ["reference", { only: ["Image"] }],
-  },
-  extractTextAttributes: ["testimonial"],
-});
-
-export default TestimonialWidget;
+export const TestimonialWidget = Scrivito.provideWidgetClass(
+  "TestimonialWidget",
+  {
+    onlyInside: "TestimonialSliderWidget",
+    attributes: {
+      testimonial: "string",
+      author: "string",
+      authorImage: ["reference", { only: ["Image"] }],
+    },
+    extractTextAttributes: ["testimonial"],
+  }
+);

--- a/src/Widgets/TextWidget/TextWidgetClass.js
+++ b/src/Widgets/TextWidget/TextWidgetClass.js
@@ -1,11 +1,9 @@
 import * as Scrivito from "scrivito";
 
-const TextWidget = Scrivito.provideWidgetClass("TextWidget", {
+export const TextWidget = Scrivito.provideWidgetClass("TextWidget", {
   attributes: {
     text: "html",
     alignment: ["enum", { values: ["left", "center", "right"] }],
   },
   extractTextAttributes: ["text"],
 });
-
-export default TextWidget;

--- a/src/Widgets/ThumbnailGalleryImageWidget/ThumbnailGalleryImageWidgetClass.js
+++ b/src/Widgets/ThumbnailGalleryImageWidget/ThumbnailGalleryImageWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const ThumbnailGalleryImageWidget = Scrivito.provideWidgetClass(
+export const ThumbnailGalleryImageWidget = Scrivito.provideWidgetClass(
   "ThumbnailGalleryImageWidget",
   {
     onlyInside: "ThumbnailGalleryWidget",
@@ -12,5 +12,3 @@ const ThumbnailGalleryImageWidget = Scrivito.provideWidgetClass(
     },
   }
 );
-
-export default ThumbnailGalleryImageWidget;

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetClass.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const ThumbnailGalleryWidget = Scrivito.provideWidgetClass(
+export const ThumbnailGalleryWidget = Scrivito.provideWidgetClass(
   "ThumbnailGalleryWidget",
   {
     attributes: {
@@ -9,5 +9,3 @@ const ThumbnailGalleryWidget = Scrivito.provideWidgetClass(
     },
   }
 );
-
-export default ThumbnailGalleryWidget;

--- a/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
+++ b/src/Widgets/ThumbnailGalleryWidget/ThumbnailGalleryWidgetComponent.js
@@ -2,10 +2,10 @@ import * as React from "react";
 import * as Scrivito from "scrivito";
 import loadable from "@loadable/component";
 
-import fullScreenWidthPixels from "../../utils/fullScreenWidthPixels";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
-import TagList from "../../Components/TagList";
-import isImage from "../../utils/isImage";
+import { fullScreenWidthPixels } from "../../utils/fullScreenWidthPixels";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
+import { TagList } from "../../Components/TagList";
+import { isImage } from "../../utils/isImage";
 import "./ThumbnailGalleryWidget.scss";
 
 const ReactBnbGallery = loadable(() => import("react-bnb-gallery"));

--- a/src/Widgets/TickListItemWidget/TickListItemWidgetClass.js
+++ b/src/Widgets/TickListItemWidget/TickListItemWidgetClass.js
@@ -1,11 +1,12 @@
 import * as Scrivito from "scrivito";
 
-const TickListItemWidget = Scrivito.provideWidgetClass("TickListItemWidget", {
-  onlyInside: "TickListWidget",
-  attributes: {
-    statement: "string",
-  },
-  extractTextAttributes: ["statement"],
-});
-
-export default TickListItemWidget;
+export const TickListItemWidget = Scrivito.provideWidgetClass(
+  "TickListItemWidget",
+  {
+    onlyInside: "TickListWidget",
+    attributes: {
+      statement: "string",
+    },
+    extractTextAttributes: ["statement"],
+  }
+);

--- a/src/Widgets/TickListWidget/TickListWidgetClass.js
+++ b/src/Widgets/TickListWidget/TickListWidgetClass.js
@@ -1,10 +1,8 @@
 import * as Scrivito from "scrivito";
 
-const TickListWidget = Scrivito.provideWidgetClass("TickListWidget", {
+export const TickListWidget = Scrivito.provideWidgetClass("TickListWidget", {
   attributes: {
     items: ["widgetlist", { only: "TickListItemWidget" }],
   },
   extractTextAttributes: ["items"],
 });
-
-export default TickListWidget;

--- a/src/Widgets/TickListWidget/TickListWidgetEditingConfig.js
+++ b/src/Widgets/TickListWidget/TickListWidgetEditingConfig.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 import tickListWidgetIcon from "../../assets/images/tick_list_widget.svg";
-import TickListItemWidget from "../TickListItemWidget/TickListItemWidgetClass";
+import { TickListItemWidget } from "../TickListItemWidget/TickListItemWidgetClass";
 
 Scrivito.provideEditingConfig("TickListWidget", {
   title: "Tick List",

--- a/src/Widgets/VideoWidget/VideoWidgetClass.js
+++ b/src/Widgets/VideoWidget/VideoWidgetClass.js
@@ -1,10 +1,8 @@
 import * as Scrivito from "scrivito";
 
-const VideoWidget = Scrivito.provideWidgetClass("VideoWidget", {
+export const VideoWidget = Scrivito.provideWidgetClass("VideoWidget", {
   attributes: {
     source: ["reference", { only: ["Video"] }],
     poster: ["reference", { only: ["Image"] }],
   },
 });
-
-export default VideoWidget;

--- a/src/Widgets/VideoWidget/VideoWidgetComponent.js
+++ b/src/Widgets/VideoWidget/VideoWidgetComponent.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import urlFromBinary from "../../utils/urlFromBinary";
-import videoPlaceholder from "./videoPlaceholder";
+import { urlFromBinary } from "../../utils/urlFromBinary";
+import { videoPlaceholder } from "./videoPlaceholder";
 
 Scrivito.provideComponent("VideoWidget", ({ widget }) => {
   const videoUrl = urlFromBinary(widget.get("source"));

--- a/src/Widgets/VideoWidget/videoPlaceholder.js
+++ b/src/Widgets/VideoWidget/videoPlaceholder.js
@@ -1,4 +1,4 @@
-const videoPlaceholder = {
+export const videoPlaceholder = {
   backgroundColor: "#ccc",
   backgroundImage:
     'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAABaklEQVR42u3bIU7DcBTA4YWQIDAYFI4TECwGg+cIOLAEJIIDwCUaxNamGaoCxBBguQEOzwkYvJItWaYJfR3flzzbpvll7dr+OxgAAAAAAAAAAAAAACuvLMuvVR1BBBFEEEEE+fdBqqq6Go1Gxz2a81UPctizY9gTRJD+BIltnDRNsyFIniBPMa91Xe8KkidIu61pe9EVpOsgVfmxuL2IcjOZTNYFSRJkNs8xO4LkCdLOZ8yRIHmC/ESJU9h1WBMkR5D5PMRsC5InSDvv8Ws5ECRPkPn+LgRJFGQ29+PxeEuQPEHaeRsOh/uC5AnS7nsacypIkiALd/d3RVFsCpIkyGwqQfxCBFm+hkSMM9cQ/7IEcR+SNEicoi7dqXuWJcjSPHramyOI9yGJgnhjmCjIi3fqeYLcWnXSZRDrslIGsXIxURBrezMF6eAYBBHkb4P4gipTEN8YCiKIIIIIIggAAAAAAAAAAAAA/KpvIMhShRPBqAoAAAAASUVORK5CYII=")',
@@ -6,5 +6,3 @@ const videoPlaceholder = {
   backgroundPosition: "center",
   opacity: 0.5,
 };
-
-export default videoPlaceholder;

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetClass.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetClass.js
@@ -1,13 +1,14 @@
 import * as Scrivito from "scrivito";
 
-const VimeoVideoWidget = Scrivito.provideWidgetClass("VimeoVideoWidget", {
-  attributes: {
-    vimeoVideoId: "string",
-    aspectRatio: [
-      "enum",
-      { values: ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"] },
-    ],
-  },
-});
-
-export default VimeoVideoWidget;
+export const VimeoVideoWidget = Scrivito.provideWidgetClass(
+  "VimeoVideoWidget",
+  {
+    attributes: {
+      vimeoVideoId: "string",
+      aspectRatio: [
+        "enum",
+        { values: ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"] },
+      ],
+    },
+  }
+);

--- a/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
+++ b/src/Widgets/VimeoVideoWidget/VimeoVideoWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 import "./VimeoVideoWidget.scss";
 
 Scrivito.provideComponent("VimeoVideoWidget", ({ widget }) => {

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetClass.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetClass.js
@@ -1,13 +1,14 @@
 import * as Scrivito from "scrivito";
 
-const YoutubeVideoWidget = Scrivito.provideWidgetClass("YoutubeVideoWidget", {
-  attributes: {
-    youtubeVideoId: "string",
-    aspectRatio: [
-      "enum",
-      { values: ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"] },
-    ],
-  },
-});
-
-export default YoutubeVideoWidget;
+export const YoutubeVideoWidget = Scrivito.provideWidgetClass(
+  "YoutubeVideoWidget",
+  {
+    attributes: {
+      youtubeVideoId: "string",
+      aspectRatio: [
+        "enum",
+        { values: ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"] },
+      ],
+    },
+  }
+);

--- a/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
+++ b/src/Widgets/YoutubeVideoWidget/YoutubeVideoWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import InPlaceEditingPlaceholder from "../../Components/InPlaceEditingPlaceholder";
+import { InPlaceEditingPlaceholder } from "../../Components/InPlaceEditingPlaceholder";
 import "./YoutubeVideoWidget.scss";
 
 Scrivito.provideComponent("YoutubeVideoWidget", ({ widget }) => {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import * as ReactDOM from "react-dom";
 import * as Scrivito from "scrivito";
 import "./Objs";
 import "./Widgets";
-import App from "./App";
+import { App } from "./App";
 import { configure } from "./config";
 import "./assets/stylesheets/index.scss";
 

--- a/src/prerenderContent/contentHash.js
+++ b/src/prerenderContent/contentHash.js
@@ -1,6 +1,6 @@
 import md4 from "js-md4";
 
 /** Generates a 20 long hex value, based the md4 of the given string */
-export default async function contentHash(input) {
+export async function contentHash(input) {
   return md4(input).substr(0, 20);
 }

--- a/src/prerenderContent/filenameFromUrl.js
+++ b/src/prerenderContent/filenameFromUrl.js
@@ -1,4 +1,4 @@
-export default function filenameFromUrl(url) {
+export function filenameFromUrl(url) {
   const { pathname } = new URL(url);
   if (pathname === "/") return "/index.html";
 

--- a/src/prerenderContent/generateHtml.js
+++ b/src/prerenderContent/generateHtml.js
@@ -1,4 +1,4 @@
-export default async function generateHtml({
+export async function generateHtml({
   objId,
   htmlAttributes,
   headContent,

--- a/src/prerenderContent/generatePreloadDump.js
+++ b/src/prerenderContent/generatePreloadDump.js
@@ -1,4 +1,4 @@
-export default function generatePreloadDump(preloadDump) {
+export function generatePreloadDump(preloadDump) {
   return `window.preloadDump = ${stringLiteral(preloadDump)};`;
 }
 

--- a/src/prerenderContent/prerenderObj.js
+++ b/src/prerenderContent/prerenderObj.js
@@ -3,7 +3,7 @@ import * as ReactDOMServer from "react-dom/server";
 import * as Scrivito from "scrivito";
 import { HelmetProvider } from "react-helmet-async";
 
-import { App } from "../App";
+import { App, helmetContext } from "../App";
 import { contentHash } from "./contentHash";
 import { filenameFromUrl } from "./filenameFromUrl";
 import { generateHtml } from "./generateHtml";

--- a/src/prerenderContent/prerenderObj.js
+++ b/src/prerenderContent/prerenderObj.js
@@ -3,13 +3,13 @@ import * as ReactDOMServer from "react-dom/server";
 import * as Scrivito from "scrivito";
 import { HelmetProvider } from "react-helmet-async";
 
-import App, { helmetContext } from "../App";
-import contentHash from "./contentHash";
-import filenameFromUrl from "./filenameFromUrl";
-import generateHtml from "./generateHtml";
-import generatePreloadDump from "./generatePreloadDump";
+import { App } from "../App";
+import { contentHash } from "./contentHash";
+import { filenameFromUrl } from "./filenameFromUrl";
+import { generateHtml } from "./generateHtml";
+import { generatePreloadDump } from "./generatePreloadDump";
 
-export default async function prerenderObj(obj, assetManifest) {
+export async function prerenderObj(obj, assetManifest) {
   HelmetProvider.canUseDOM = false;
 
   const { result, preloadDump } = await Scrivito.renderPage(obj, () => {

--- a/src/prerenderContent/prerenderObjs.js
+++ b/src/prerenderContent/prerenderObjs.js
@@ -1,10 +1,10 @@
 import * as Scrivito from "scrivito";
 import { chunk } from "lodash-es";
-import prerenderObj from "./prerenderObj";
+import { prerenderObj } from "./prerenderObj";
 import { reportError } from "./reportError";
 import { storeResult } from "./storeResult";
 
-export default async function prerenderObjs(
+export async function prerenderObjs(
   targetDir,
   objClassesBlacklist,
   assetManifest

--- a/src/prerenderContent/prerenderSitemap.js
+++ b/src/prerenderContent/prerenderSitemap.js
@@ -1,9 +1,9 @@
 import * as Scrivito from "scrivito";
 import jsontoxml from "jsontoxml";
-import formatDate from "../utils/formatDate";
+import { formatDate } from "../utils/formatDate";
 import { storeResult } from "./storeResult";
 
-export default async function prerenderSitemap(targetDir, objClassesWhitelist) {
+export async function prerenderSitemap(targetDir, objClassesWhitelist) {
   console.time("[prerenderSitemap]");
 
   const pages = await Scrivito.load(() =>

--- a/src/prerender_content.js
+++ b/src/prerender_content.js
@@ -3,8 +3,8 @@ import fse from "fs-extra";
 import "./Objs";
 import "./Widgets";
 import { configure } from "./config";
-import prerenderObjs from "./prerenderContent/prerenderObjs";
-import prerenderSitemap from "./prerenderContent/prerenderSitemap";
+import { prerenderObjs } from "./prerenderContent/prerenderObjs";
+import { prerenderSitemap } from "./prerenderContent/prerenderSitemap";
 import { extendRedirects } from "./prerenderContent/extendRedirects";
 import { reportError } from "./prerenderContent/reportError";
 

--- a/src/utils/devicePixelRatio.js
+++ b/src/utils/devicePixelRatio.js
@@ -1,5 +1,3 @@
-function devicePixelRatio() {
+export function devicePixelRatio() {
   return window.devicePixelRatio || 1;
 }
-
-export default devicePixelRatio;

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,10 +1,8 @@
 import dateFormat from "dateformat";
 
-function formatDate(date, format) {
+export function formatDate(date, format) {
   // dateFormat uses Date.now if no date is given.
   if (!date) return null;
 
   return dateFormat(date, format);
 }
-
-export default formatDate;

--- a/src/utils/fullScreenWidthPixels.js
+++ b/src/utils/fullScreenWidthPixels.js
@@ -1,4 +1,4 @@
-import devicePixelRatio from "./devicePixelRatio";
+import { devicePixelRatio } from "./devicePixelRatio";
 
 /**
  * Based on (and thus optimized for) the Lighthouse mobile emulation.
@@ -6,12 +6,10 @@ import devicePixelRatio from "./devicePixelRatio";
  * */
 const SSR_FALLBACK_WIDTH_PX = 945;
 
-function fullScreenWidthPixels() {
+export function fullScreenWidthPixels() {
   if (typeof window === "undefined") return SSR_FALLBACK_WIDTH_PX;
 
   const screenWidth = window.screen.width;
 
   return screenWidth * devicePixelRatio();
 }
-
-export default fullScreenWidthPixels;

--- a/src/utils/getMetadata.js
+++ b/src/utils/getMetadata.js
@@ -1,9 +1,9 @@
 import * as Scrivito from "scrivito";
 import { truncate } from "lodash-es";
-import urlFromBinary from "./urlFromBinary";
-import isVideoObj from "./isVideoObj";
+import { urlFromBinary } from "./urlFromBinary";
+import { isVideoObj } from "./isVideoObj";
 
-function getMetadata(page) {
+export function getMetadata(page) {
   const meta = [
     { name: "twitter:card", content: "summary_large_image" },
     { name: "prerender-status-code", content: "200" },
@@ -88,5 +88,3 @@ function firstImageUrlForAttributes(obj, attributes) {
 
   return url;
 }
-
-export default getMetadata;

--- a/src/utils/googleMapsApiKey.js
+++ b/src/utils/googleMapsApiKey.js
@@ -1,10 +1,8 @@
 import * as Scrivito from "scrivito";
 
-function googleMapsApiKey() {
+export function googleMapsApiKey() {
   const root = Scrivito.Obj.root();
   if (!root) return "";
 
   return root.get("googleMapsApiKey");
 }
-
-export default googleMapsApiKey;

--- a/src/utils/googleMapsImageUrl.js
+++ b/src/utils/googleMapsImageUrl.js
@@ -150,7 +150,7 @@ function stylingParamsArray() {
   return googleStyles.map((i) => computeStyle(i)).map((i) => ["style", i]);
 }
 
-function googleMapsImageUrl(params) {
+export function googleMapsImageUrl(params) {
   const paramsArray = Object.entries(params).concat(stylingParamsArray());
   const flattenParams = paramsArray
     .map(([key, value]) => `${key}=${value}`)
@@ -159,5 +159,3 @@ function googleMapsImageUrl(params) {
 
   return encodeURI(uri);
 }
-
-export default googleMapsImageUrl;

--- a/src/utils/isImage.js
+++ b/src/utils/isImage.js
@@ -1,5 +1,3 @@
-function isImage(object) {
+export function isImage(object) {
   return object && object.objClass() === "Image" && object.get("blob");
 }
-
-export default isImage;

--- a/src/utils/isVideoObj.js
+++ b/src/utils/isVideoObj.js
@@ -1,4 +1,4 @@
-function isVideoObj(obj) {
+export function isVideoObj(obj) {
   if (!obj) return false;
 
   const contentType = obj.contentType();
@@ -6,5 +6,3 @@ function isVideoObj(obj) {
 
   return contentType.startsWith("video/");
 }
-
-export default isVideoObj;

--- a/src/utils/navigateToBlogWithTag.js
+++ b/src/utils/navigateToBlogWithTag.js
@@ -1,10 +1,8 @@
 import * as Scrivito from "scrivito";
 
-function navigateToBlogWithTag(tag) {
+export function navigateToBlogWithTag(tag) {
   const params = {};
   if (tag) params.tag = tag;
 
   Scrivito.navigateTo(() => Scrivito.Obj.getByPermalink("blog"), params);
 }
-
-export default navigateToBlogWithTag;

--- a/src/utils/placeholderCss.js
+++ b/src/utils/placeholderCss.js
@@ -1,4 +1,4 @@
-const placeholderCss = {
+export const placeholderCss = {
   color: "rgba(64, 64, 64, 0.53)",
   display: "inline-block",
   fontSize: "13px",
@@ -7,5 +7,3 @@ const placeholderCss = {
   lineHeight: "28px",
   verticalAlign: "middle",
 };
-
-export default placeholderCss;

--- a/src/utils/urlFromBinary.js
+++ b/src/utils/urlFromBinary.js
@@ -1,4 +1,4 @@
-function urlFromBinary(binary) {
+export function urlFromBinary(binary) {
   if (!binary) return null;
 
   const blob = binary.get("blob");
@@ -6,5 +6,3 @@ function urlFromBinary(binary) {
 
   return blob.url() || null;
 }
-
-export default urlFromBinary;


### PR DESCRIPTION
This PR used the help of the codegenerator https://github.com/apepper/defaultToNamedExport .

Diff best viewed without whitespace changes applied.