### PR TITLE
Fix "npm run es-check" error.

### DIFF
--- a/src/config/history.js
+++ b/src/config/history.js
@@ -16,6 +16,6 @@ let currentHistory;
 export function getHistory() {
   if (typeof window === "undefined") return;
 
-  currentHistory ||= createBrowserHistory();
+  if (!currentHistory) currentHistory = createBrowserHistory();
   return currentHistory;
 }


### PR DESCRIPTION
Logical OR assignment seems to be not well supported by the current tools.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment

Follow up of https://github.com/Scrivito/scrivito_example_app_js/pull/496. I assume that some package of #497 does handle Logical OR assignment differently.