### PR TITLE
Allow sorting children for all types of objects by default

### DIFF
--- a/src/Objs/Homepage/HomepageObjClass.js
+++ b/src/Objs/Homepage/HomepageObjClass.js
@@ -8,7 +8,6 @@ export const Homepage = Scrivito.provideObjClass("Homepage", {
     showAsLandingPage: "boolean",
     cookieConsentLink: "link",
     contentTitle: "string",
-    childOrder: "referencelist",
     footer: ["widgetlist", { only: "SectionWidget" }],
     logoDark: ["reference", { only: ["Image"] }],
     logoWhite: ["reference", { only: ["Image"] }],

--- a/src/Objs/Page/PageObjClass.js
+++ b/src/Objs/Page/PageObjClass.js
@@ -5,7 +5,6 @@ import { defaultPageAttributes } from "../_defaultPageAttributes";
 export const Page = Scrivito.provideObjClass("Page", {
   attributes: {
     ...defaultPageAttributes,
-    childOrder: "referencelist",
     ...metadataAttributes,
   },
   extractTextAttributes: ["navigationSection", "body"],

--- a/src/Objs/_metadataAttributes.js
+++ b/src/Objs/_metadataAttributes.js
@@ -11,4 +11,6 @@ export const metadataAttributes = {
   ogDescription: "string",
   ogImage: ["reference", { only: ["Image"] }],
   ogTitle: "string",
+  // The order of the child pages
+  childOrder: "referencelist",
 };


### PR DESCRIPTION
The order of the child pages is defined by the `childOrder` attribute of the parent page. This attribute is assumed to be of the [referencelist](https://www.scrivito.com/custom-attribute-types-a0a749848457286c) type. If it’s missing in the corresponding [page class definition](https://www.scrivito.com/js-sdk/createObjClass), then the children are ordered randomly, and it will not be possible for editors to adjust this order.

I think it would make sense to allow sorting children for all types of objects by default. Especially if UI is ready for this and Editor can confused why she/he can't use this feature.

<img width="269" alt="image" src="https://user-images.githubusercontent.com/292416/208421064-9e9eb902-a9a7-466a-bf9d-27aea328f7d8.png">
