### PR TITLE
fix component order

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,9 +16,9 @@ export const helmetContext = {};
 
 export function App({ appWrapperRef }) {
   return (
-    <ErrorBoundary>
-      <CookieConsentProvider>
-        <HelmetProvider context={helmetContext}>
+    <HelmetProvider context={helmetContext}>
+      <ErrorBoundary>
+        <CookieConsentProvider>
           <React.Suspense>
             <div ref={appWrapperRef}>
               <div className="content-wrapper">
@@ -37,8 +37,8 @@ export function App({ appWrapperRef }) {
               <Intercom />
             </div>
           </React.Suspense>
-        </HelmetProvider>
-      </CookieConsentProvider>
-    </ErrorBoundary>
+        </CookieConsentProvider>
+      </ErrorBoundary>
+    </HelmetProvider>
   );
 }


### PR DESCRIPTION
wrong component order leads to error in older versions of [ErrorBoundary.js](https://github.com/Scrivito/scrivito_example_app_js/blob/907d43020c9a91f531cb8f242e5aa20ac406a673/src/Components/ErrorBoundary.js)

see discussion in https://infopark.slack.com/archives/C5LGN1D42/p1674119386473099