### PR TITLE
HeadlineWidget: Improved automatic anchors.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "scrivito": "^1.31.0",
         "scroll-to-fragment": "^1.0.12",
         "slick-carousel": "^1.6.0",
+        "speakingurl": "^14.0.1",
         "typescript": "^4.8.4",
         "use-resize-observer": "^9.0.2",
         "webpack": "^5.74.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "scrivito": "^1.31.0",
     "scroll-to-fragment": "^1.0.12",
     "slick-carousel": "^1.6.0",
+    "speakingurl": "^14.0.1",
     "typescript": "^4.8.4",
     "use-resize-observer": "^9.0.2",
     "webpack": "^5.74.0",

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
@@ -19,7 +19,7 @@ Scrivito.provideComponent("HeadlineWidget", ({ widget }) => {
     <>
       <span
         className="headline-widget--anchor"
-        id={kebabCase(widget.get("headline"))}
+        id={kebabCase(widget.get("headline").toLowerCase())}
       ></span>
       <Scrivito.ContentTag
         tag={level}

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import { kebabCase } from "lodash-es";
+import * as speakingUrl from "speakingurl";
 import "./HeadlineWidget.scss";
 import { alignmentClassName } from "../../utils/alignmentClassName";
 
@@ -19,7 +19,7 @@ Scrivito.provideComponent("HeadlineWidget", ({ widget }) => {
     <>
       <span
         className="headline-widget--anchor"
-        id={kebabCase(widget.get("headline").toLowerCase())}
+        id={speakingUrl(widget.get("headline"))}
       ></span>
       <Scrivito.ContentTag
         tag={level}


### PR DESCRIPTION
kebabCase will try to covert camelCase to camel-case:

```js
_.kebabCase('fooBar');
// => 'foo-bar'
```

Source: https://lodash.com/docs/4.17.15#kebabCase

This can have undesirable effects, if one inputs "normal" text. E.g. 

```js
_.kebabCase("Mapping sites and URLs dynamically")
// => "mapping-sites-and-ur-ls-dynamically"
```

With this change the anchor now looks like this:
```js
// => "mapping-sites-and-urls-dynamically"
```