### PR TITLE
Fix property text inputs on Firefox

### DIFF
--- a/src/assets/stylesheets/_scrivito_extensions.scss
+++ b/src/assets/stylesheets/_scrivito_extensions.scss
@@ -13,6 +13,7 @@
   padding: 0 8px;
   min-height: 30px;
   line-height: 30px;
+  word-break: break-all;
 }
 .content_property_input:focus {
   box-shadow: 0 0 0 2px #577fb6 inset !important;

--- a/src/assets/stylesheets/_social_cards.scss
+++ b/src/assets/stylesheets/_social_cards.scss
@@ -10,6 +10,8 @@
     font-weight: bold;
     padding: 6px 3px 0 3px;
     color: #2b7bb9;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .card {
     border-radius: 4px;


### PR DESCRIPTION
| before | after |
| -- | -- |
| <img width="296" alt="image" src="https://github.com/Scrivito/scrivito_example_app_js/assets/986170/49aea6cb-06c3-4068-a805-84b1e0333333"> |  <img width="272" alt="image" src="https://github.com/Scrivito/scrivito_example_app_js/assets/986170/b988dcc3-fc89-4811-8777-d6e9c2d426ad"> |


This lead to bad UX if the input contains words longer than the available width, which happens most frequently in sidebar editing. Chrome automatically uses this style for contenteditable. Now, all browsers behave the same.