### PR TITLE
Replace headline widget scroll margin workaround

### DIFF
--- a/src/Widgets/HeadlineWidget/HeadlineWidget.scss
+++ b/src/Widgets/HeadlineWidget/HeadlineWidget.scss
@@ -1,9 +1,0 @@
-.headline-widget {
-  // Fix navigation overlapping anchor issue
-  // See .navbar "min-height" value
-  // Source: https://stackoverflow.com/a/38106970/881759
-  &--anchor {
-    position: relative;
-    top: -75px;
-  }
-}

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.js
@@ -1,13 +1,12 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
 import * as speakingUrl from "speakingurl";
-import "./HeadlineWidget.scss";
 import { alignmentClassName } from "../../utils/alignmentClassName";
 
 Scrivito.provideComponent("HeadlineWidget", ({ widget }) => {
   const style = widget.get("style") || "h2";
   const level = widget.get("level") || style;
-  const classNames = ["headline-widget", style];
+  const classNames = [style];
 
   const alignment = alignmentClassName(widget.get("alignment"));
   if (alignment) classNames.push(alignment);
@@ -16,17 +15,12 @@ Scrivito.provideComponent("HeadlineWidget", ({ widget }) => {
   if (!widget.get("showMargin")) classNames.push("no-margin");
 
   return (
-    <>
-      <span
-        className="headline-widget--anchor"
-        id={speakingUrl(widget.get("headline"))}
-      ></span>
-      <Scrivito.ContentTag
-        tag={level}
-        content={widget}
-        attribute="headline"
-        className={classNames.join(" ")}
-      />
-    </>
+    <Scrivito.ContentTag
+      tag={level}
+      content={widget}
+      attribute="headline"
+      className={classNames.join(" ")}
+      id={speakingUrl(widget.get("headline"))}
+    />
   );
 });

--- a/src/assets/stylesheets/_navigation.scss
+++ b/src/assets/stylesheets/_navigation.scss
@@ -271,6 +271,10 @@
   }
 }
 
+[id] {
+  scroll-margin-top: 75px;
+}
+
 /* menu toggle */
 
 .menu-toggle {


### PR DESCRIPTION
Also fixes the scroll margin for other link targets (e.g. #mainContent).

Examples:

* https://deploy-preview-525--scrivito-example.netlify.app/#mainContent
* https://deploy-preview-525--scrivito-example.netlify.app/pricing#compare-all-features
* https://deploy-preview-525--scrivito-example.netlify.app/pages-and-widgets#form_text_input_widget_2fd9e8a7