### PR TITLE
Neoletter || Form builder || Add subscription checkbox type 

### DIFF
--- a/src/Widgets/FormCheckboxWidget/FormCheckboxWidgetClass.js
+++ b/src/Widgets/FormCheckboxWidget/FormCheckboxWidgetClass.js
@@ -4,7 +4,16 @@ export const FormCheckboxWidget = Scrivito.provideWidgetClass(
   "FormCheckboxWidget",
   {
     attributes: {
-      type: ["enum", { values: ["custom", "accept_terms"] }],
+      type: [
+        "enum",
+        {
+          values: ["custom", "accept_terms"].concat(
+            process.env.ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE
+              ? ["subscription"]
+              : []
+          ),
+        },
+      ],
       customFieldName: "string",
       label: "string",
       required: "boolean",

--- a/src/Widgets/FormCheckboxWidget/FormCheckboxWidgetEditingConfig.js
+++ b/src/Widgets/FormCheckboxWidget/FormCheckboxWidgetEditingConfig.js
@@ -15,7 +15,11 @@ Scrivito.provideEditingConfig("FormCheckboxWidget", {
       values: [
         { value: "accept_terms", title: "Accept terms" },
         { value: "custom", title: "Custom" },
-      ],
+      ].concat(
+        process.env.ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE
+          ? [{ value: "subscription", title: "Subscription" }]
+          : []
+      ),
     },
     customFieldName: { title: "Field name" },
     helpText: { title: "Help text" },

--- a/src/Widgets/FormCheckboxWidget/FormCheckboxWidgetEditingConfig.js
+++ b/src/Widgets/FormCheckboxWidget/FormCheckboxWidgetEditingConfig.js
@@ -14,12 +14,11 @@ Scrivito.provideEditingConfig("FormCheckboxWidget", {
       title: "Input type",
       values: [
         { value: "accept_terms", title: "Accept terms" },
-        { value: "custom", title: "Custom" },
-      ].concat(
-        process.env.ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE
+        ...(process.env.ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE
           ? [{ value: "subscription", title: "Subscription" }]
-          : []
-      ),
+          : []),
+        { value: "custom", title: "Custom" },
+      ],
     },
     customFieldName: { title: "Field name" },
     helpText: { title: "Help text" },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,6 +118,7 @@ function webpackConfig(env = {}) {
         SCRIVITO_ENDPOINT: "",
         SCRIVITO_ORIGIN: scrivitoOrigin,
         SCRIVITO_TENANT: "",
+        ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE: false,
       }),
       new Webpackbar(),
       new CopyWebpackPlugin({


### PR DESCRIPTION
Neoletter has introduced partial (beta) support for "subscription". To make this feature compatible with the example app "Form Builder," I've implemented the first change by introducing a new checkbox type "subscription". 

As the "subscription" feature is still in its development stage and not yet documented, it remains concealed for standard users. Following the approach taken during the initial stages of Form Builder, I have opted to hide the "subscription" functionality under a special environment variable. 

`ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE`

This approach ensures that the feature is accessible for testing and refinement while remaining hidden from regular users until it is fully prepared for deployment.

This initial pull request sets the groundwork for the integration of Neoletter subscription feature with Form Builder.

<img width="828" alt="Screenshot 2023-07-24 at 14 44 39" src="https://github.com/Scrivito/scrivito_example_app_js/assets/31543263/157af493-af7f-448a-9db5-f398c5f773b2">
<img width="417" alt="Screenshot 2023-07-24 at 14 44 43" src="https://github.com/Scrivito/scrivito_example_app_js/assets/31543263/84e3a9cc-8732-4d15-a9b5-e81931b530ac">


cc @jfienhold @7ack7