### PR TITLE
Bugfix: FormButtonWidget now positions "right" alignment correctly.

### DIFF
--- a/src/Widgets/FormButtonWidget/FormButtonWidgetComponent.js
+++ b/src/Widgets/FormButtonWidget/FormButtonWidgetComponent.js
@@ -1,13 +1,9 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
+import { alignmentClassName } from "../../utils/alignmentClassName";
 
 Scrivito.provideComponent("FormButtonWidget", ({ widget }) => (
-  <WrapIfClassName
-    className={
-      ["center", "right"].includes(widget.get("alignment")) &&
-      `text-${widget.get("alignment")}`
-    }
-  >
+  <WrapIfClassName className={alignmentClassName(widget.get("alignment"))}>
     <button
       className={`btn btn-primary${
         widget.get("alignment") === "block" ? " btn-block" : ""


### PR DESCRIPTION
Reported by @aea-JR in https://infopark.slack.com/archives/C5LGN1D42/p1689268699147859.