### PR TITLE
Neoletter | Form Builder | Subscription as a hidden field 

### DIFF
--- a/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetClass.js
+++ b/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetClass.js
@@ -5,6 +5,16 @@ export const FormHiddenFieldWidget = Scrivito.provideWidgetClass(
   {
     onlyInside: "FormContainerWidget",
     attributes: {
+      type: [
+        "enum",
+        {
+          values: ["custom"].concat(
+            process.env.ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE
+              ? ["subscription"]
+              : []
+          ),
+        },
+      ],
       customFieldName: "string",
       hiddenValue: "string",
     },

--- a/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetEditingConfig.js
+++ b/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetEditingConfig.js
@@ -1,19 +1,42 @@
 import * as Scrivito from "scrivito";
 import formHiddenFieldWidgetIcon from "../../assets/images/form_hidden_field_widget.svg";
 import { customFieldNameValidation } from "../FormContainerWidget/utils/validations/customFieldNameValidation";
+import { isCustomType } from "../FormContainerWidget/utils/isCustomType";
+import { typeValidation } from "../FormContainerWidget/utils/validations/typeValidation";
+import { getFieldName } from "../FormContainerWidget/utils/getFieldName";
 
 Scrivito.provideEditingConfig("FormHiddenFieldWidget", {
   title: "Hidden Form Field",
   thumbnail: formHiddenFieldWidgetIcon,
   attributes: {
+    type: {
+      title: "Input type",
+      values: [
+        { value: "custom", title: "Custom" },
+        ...(process.env.ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE
+          ? [{ value: "subscription", title: "Subscription" }]
+          : []),
+      ],
+    },
     customFieldName: { title: "Field name" },
     hiddenValue: {
       title: "Hidden value",
       description: "This value is sent on every submission of the form.",
     },
   },
-  properties: ["customFieldName", "hiddenValue"],
+  properties: (widget) => {
+    if (process.env.ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE) {
+      if (!isCustomType(widget)) {
+        return ["type", "hiddenValue"];
+      }
+
+      return ["type", "customFieldName", "hiddenValue"];
+    }
+
+    return ["customFieldName", "hiddenValue"];
+  },
   initialContent: {
+    type: "custom",
     customFieldName: "custom_hidden_field",
   },
   validations: [
@@ -34,12 +57,32 @@ Scrivito.provideEditingConfig("FormHiddenFieldWidget", {
         severity: "info",
       };
     },
-  ],
-  titleForContent: (widget) =>
-    `Hidden Form Field: ${[
-      widget.get("customFieldName"),
-      widget.get("hiddenValue"),
-    ]
+  ].concat(
+    process.env.ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE
+      ? [
+          typeValidation,
+          [
+            "hiddenValue",
+            (hiddenValue, { widget }) => {
+              const fieldName = getFieldName(widget);
+
+              if (fieldName === "subscription" && hiddenValue !== "on") {
+                return {
+                  message:
+                    "Please enter 'on' to activate the subscription process on every submission.",
+                  severity: "warning",
+                };
+              }
+            },
+          ],
+        ]
+      : []
+  ),
+  titleForContent: (widget) => {
+    const fieldName = getFieldName(widget);
+
+    return `Hidden Form Field: ${[fieldName, widget.get("hiddenValue")]
       .filter((e) => e)
-      .join(" - ")}`,
+      .join(" - ")}`;
+  },
 });


### PR DESCRIPTION
Related to https://github.com/Scrivito/scrivito_example_app_js/pull/535

To make the subscription process more straightforward, we've made a change in the Form Builder. Previously, users had to actively check a specific checkbox to subscribe. We realized this step might not be necessary for all types of subscription forms. To simplify the process, we've incorporated the subscription action as a hidden field within the form. This means that when users fill out the form, the subscription process is initiated without the need for the user to check an additional checkbox.

Currently, subscription feature-related fields are activated when the ENABLE_NEOLETTER_FORM_BUILDER_SUBSCRIPTION_FEATURE environment variable flag is set.

Without flag: 
<img width="422" alt="Screenshot 2023-08-21 at 14 27 35" src="https://github.com/Scrivito/scrivito_example_app_js/assets/31543263/6fe04326-389e-44a5-96b8-afb39f499ad6">


With flag: 
<img width="413" alt="Screenshot 2023-08-21 at 14 13 54" src="https://github.com/Scrivito/scrivito_example_app_js/assets/31543263/7cc6c4af-fdaa-4c40-b082-956c22a6894b">
<img width="420" alt="Screenshot 2023-08-21 at 14 13 59" src="https://github.com/Scrivito/scrivito_example_app_js/assets/31543263/e9dbcf78-0a1e-493f-804e-71cc1406e887">
<img width="410" alt="Screenshot 2023-08-21 at 14 14 10" src="https://github.com/Scrivito/scrivito_example_app_js/assets/31543263/2183c5e5-4502-4616-87f9-1a80efaf037d">

