### PR TITLE
Form Builder || fix honeypot by adding presentation role to the fax field

### DIFF
--- a/src/Widgets/FormContainerWidget/FormContainerWidgetComponent.js
+++ b/src/Widgets/FormContainerWidget/FormContainerWidgetComponent.js
@@ -120,7 +120,7 @@ async function submit(formElement, formEndpoint) {
 
 const HoneypotField = () => (
   <div aria-hidden="true" className="winnie-the-pooh">
-    <input autoComplete="off" name="fax" tabIndex="-1" />
+    <input autoComplete="off" role="presentation" name="fax" tabIndex="-1" />
   </div>
 );
 


### PR DESCRIPTION
Despite setting autoComplete to 'off' the fax field was auto-filled in Chrome and Brave browsers. I resolved the issue using the suggestion from [this gist](https://gist.github.com/niksumeiko/360164708c3b326bd1c8?permalink_comment_id=4405851#gistcomment-4405851).