### PR TITLE
Bugfix on reseting the search for icons

### DIFF
--- a/src/Components/ScrivitoExtensions/IconEditorTab/IconSearch.js
+++ b/src/Components/ScrivitoExtensions/IconEditorTab/IconSearch.js
@@ -41,7 +41,7 @@ function ClearSearchButton({ setSearchValue, searchValue }) {
       href="#"
       className="fa fa-times-circle"
       aria-hidden="true"
-      onClick={(e) => setSearchValue(e, "")}
+      onClick={() => setSearchValue("")}
     >
       <span className="sr-only">Clear search</span>
     </a>


### PR DESCRIPTION
This will fix the [Object Object] bug caused when reseting the icon search in IconEditorTab component.