### PR TITLE
Fix ESLint if SCRIVITO_TENANT is unset

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   "parser": "@babel/eslint-parser",
   "plugins": ["import", "prettier", "react"],
   "settings": {
-    "import/resolver": "webpack",
+    "import/resolver": { "webpack": { "env": { "ESLINT": true } } },
     "react": { "version": "16" }
   },
   "parserOptions": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,9 @@ const BUILD_DIR = "build";
 
 function webpackConfig(env = {}) {
   if (
-    !process.env.SCRIVITO_TENANT ||
-    process.env.SCRIVITO_TENANT === "your_scrivito_tenant_id"
+    !env.ESLINT &&
+    (!process.env.SCRIVITO_TENANT ||
+      process.env.SCRIVITO_TENANT === "your_scrivito_tenant_id")
   ) {
     throw new Error(
       'Environment variable "SCRIVITO_TENANT" is not defined!' +


### PR DESCRIPTION
Without this, `npm run eslint` fails with
```
✖ 3499 problems (3499 errors, 0 warnings)
```

The README doesn't mention `.env` with `SCRIVITO_TENANT` as a prerequisite for developing, so
I think `ESLint` should work out of the box.